### PR TITLE
Code clarity (path strings) and enhanced performance

### DIFF
--- a/salted/aims/collect_energies.py
+++ b/salted/aims/collect_energies.py
@@ -1,13 +1,12 @@
 import os
 import sys
-from os import listdir
 
 import numpy as np
 
 import inp
 
 dn = os.path.join(inp.path2qm, inp.predict_data)
-l = listdir(dn+'geoms/')
+l = os.listdir(os.path.join(dn, "geoms"))
 nfiles = len(l)
 testset = list(range(nfiles))
 testset = [x+1 for x in testset]
@@ -23,8 +22,8 @@ for k,i in enumerate(testset):
     xc = []
     har = []
     ele = []
-    dirn = dn+str(i)+'/'
-    
+    dirn = os.path.join(dn, str(i))
+
     f1 = open(dirn+'aims.out')
     for line in f1:
         if line.find('| Number of atoms') != -1:

--- a/salted/aims/collect_energies.py
+++ b/salted/aims/collect_energies.py
@@ -1,9 +1,12 @@
-import numpy as np
+import os
 import sys
-import inp
 from os import listdir
 
-dn = inp.path2qm+inp.predict_data
+import numpy as np
+
+import inp
+
+dn = os.path.join(inp.path2qm, inp.predict_data)
 l = listdir(dn+'geoms/')
 nfiles = len(l)
 testset = list(range(nfiles))

--- a/salted/aims/get_basis_info.py
+++ b/salted/aims/get_basis_info.py
@@ -1,7 +1,11 @@
-import inp
+import os
+import os.path as osp
+
 import numpy as np
 from ase.io import read
+
 from salted import basis
+import inp
 
 # read species
 spelist = inp.species
@@ -10,7 +14,7 @@ xyzfile = read(inp.filename,":")
 
 done_list = []
 
-dirpath = inp.path2qm + 'data/'
+dirpath = osp.join(inp.path2qm, 'data')
 
 afname = basis.__file__
 
@@ -22,11 +26,11 @@ for iconf in range(len(xyzfile)):
     for iat in range(natoms):
         spe = atomic_symbols[iat]
         if spe not in done_list:
-            f = open(dirpath+str(iconf+1)+'/basis_info.out')
+            f = open(osp.join(dirpath, str(iconf+1), 'basis_info.out'))
             l = 0
             while True:
                 line = f.readline()
-                if not line: 
+                if not line:
                     f.close()
                     break
 

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -1,9 +1,15 @@
+"""
+Compare the density from DF and from SCF, output the real space electron density MAE
+TODO: parallelize the comparison code
+"""
+
 import time
 import sys
 import os.path as osp
 
 import numpy as np
 import inp
+
 
 def sort_grid_data(data:np.ndarray) -> np.ndarray:
     """Sort real space grid data
@@ -25,13 +31,13 @@ def sort_grid_data(data:np.ndarray) -> np.ndarray:
 def main():
     from salted.sys_utils import read_system
     spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
-    
+
     start_time = time.time()
 
     dirname = osp.join(inp.path2qm, 'data')
     av_err = 0
     errs = np.zeros(ndata)
-    g = open('df_maes','w+')
+    g = open(osp.join(inp.saltedpath, 'df_maes'),'w+')  # stay in salted dir
     for i in range(1,ndata+1):
         dirn = osp.join(dirname, str(i))
         # f = open(dirn+'rho_scf.out')
@@ -69,6 +75,8 @@ def main():
     sem = np.std(errs)/np.sqrt(ndata)
 
     print('% MAE =', av_err)
-#    print(round(time.time() - start_time,1),'seconds')
+    end_time = time.time()
+    print(f"time_cost = {end_time - start_time:.2f} s")
 
-main()
+if __name__ == '__main__':
+    main()

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -31,10 +31,8 @@ def main():
     dirname = osp.join(inp.path2qm, 'data')
     av_err = 0
     errs = np.zeros(ndata)
-    # g = open('df_maes','w+')
-    # for i in range(1,ndata+1):
-    g = open('df_maes_test','w+')
-    for i in range(1,4):
+    g = open('df_maes','w+')
+    for i in range(1,ndata+1):
         dirn = osp.join(dirname, str(i))
         # f = open(dirn+'rho_scf.out')
         # r_con = [float(line.split()[-1]) for line in f]

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -5,6 +5,23 @@ import os.path as osp
 import numpy as np
 import inp
 
+def sort_grid_data(data:np.ndarray) -> np.ndarray:
+    """Sort real space grid data
+    The grid data is 2D array with 4 columns (x,y,z,value).
+    Sort the grid data in the order of x, y, z.
+
+    Args:
+        data (np.ndarray): grid data
+
+    Returns:
+        np.ndarray: sorted grid data
+    """
+    assert data.ndim == 2
+    assert data.shape[1] == 4
+    data = data[np.lexsort((data[:,2], data[:,1], data[:,0]))]  # last key is primary
+    return data
+
+
 def main():
     from salted.sys_utils import read_system
     spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
@@ -14,21 +31,34 @@ def main():
     dirname = osp.join(inp.path2qm, 'data')
     av_err = 0
     errs = np.zeros(ndata)
-    g = open('df_maes','w+')
-    for i in range(1,ndata+1):
+    # g = open('df_maes','w+')
+    # for i in range(1,ndata+1):
+    g = open('df_maes_test','w+')
+    for i in range(1,4):
         dirn = osp.join(dirname, str(i))
-#        f = open(dirn+'rho_scf.out')
-#        r_con = [float(line.split()[-1]) for line in f]
+        # f = open(dirn+'rho_scf.out')
+        # r_con = [float(line.split()[-1]) for line in f]
+        # f = open(dirn+'rho_df.out')
+        # r_ri = [float(line.split()[-1]) for line in f]
+        # f = open(dirn+'partition_tab.out')
+        # part = [float(line.split()[-1]) for line in f]
+
         r_con = np.loadtxt(osp.join(dirn, 'rho_scf.out'))
-        r_con.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
-#        f = open(dirn+'rho_df.out')
-#        r_ri = [float(line.split()[-1]) for line in f]
         r_ri = np.loadtxt(osp.join(dirn, 'rho_df.out'))
-        r_ri.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
-#        f = open(dirn+'partition_tab.out')
-#        part = [float(line.split()[-1]) for line in f]
         part = np.loadtxt(osp.join(dirn, 'partition_tab.out'))
-        part.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # print("before sort by coord")
+        # print(i, np.allclose(r_ri[:,:3], r_con[:,:3]), np.allclose(r_ri[:,:3], part[:,:3]))
+        # print(i, np.linalg.norm(r_ri[:,:3] - r_con[:,:3]), np.linalg.norm(r_ri[:,:3] - part[:,:3]))
+        r_con = sort_grid_data(r_con)
+        r_ri = sort_grid_data(r_ri)
+        part = sort_grid_data(part)
+        # r_con.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # r_ri.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # part.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # print("after sort by coord")
+        # print(i, np.allclose(r_ri[:,:3], r_con[:,:3]), np.allclose(r_ri[:,:3], part[:,:3]))
+        # print(i, np.linalg.norm(r_ri[:,:3] - r_con[:,:3]), np.linalg.norm(r_ri[:,:3] - part[:,:3]))
+
         err = np.abs(r_ri[:,3]-r_con[:,3])
         norm = np.dot(r_con[:,3],part[:,3])
         int_err = np.dot(err,part[:,3])*100/norm

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -10,23 +10,7 @@ import os.path as osp
 import numpy as np
 import inp
 
-
-def sort_grid_data(data:np.ndarray) -> np.ndarray:
-    """Sort real space grid data
-    The grid data is 2D array with 4 columns (x,y,z,value).
-    Sort the grid data in the order of x, y, z.
-
-    Args:
-        data (np.ndarray): grid data
-
-    Returns:
-        np.ndarray: sorted grid data
-    """
-    assert data.ndim == 2
-    assert data.shape[1] == 4
-    data = data[np.lexsort((data[:,2], data[:,1], data[:,0]))]  # last key is primary
-    return data
-
+from salted.sys_utils import sort_grid_data
 
 def main():
     from salted.sys_utils import read_system

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -1,6 +1,8 @@
-import numpy as np
 import time
 import sys
+import os.path as osp
+
+import numpy as np
 import inp
 
 def main():
@@ -9,23 +11,23 @@ def main():
     
     start_time = time.time()
 
-    dirname = inp.path2qm+'data/'
+    dirname = osp.join(inp.path2qm, 'data')
     av_err = 0
     errs = np.zeros(ndata)
     g = open('df_maes','w+')
     for i in range(1,ndata+1):
-        dirn = dirname+str(i)+'/'
+        dirn = osp.join(dirname, str(i))
 #        f = open(dirn+'rho_scf.out')
 #        r_con = [float(line.split()[-1]) for line in f]
-        r_con = np.loadtxt(dirn+'rho_scf.out')
+        r_con = np.loadtxt(osp.join(dirn, 'rho_scf.out'))
         r_con.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
 #        f = open(dirn+'rho_df.out')
 #        r_ri = [float(line.split()[-1]) for line in f]
-        r_ri = np.loadtxt(dirn+'rho_df.out')
+        r_ri = np.loadtxt(osp.join(dirn, 'rho_df.out'))
         r_ri.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
 #        f = open(dirn+'partition_tab.out')
 #        part = [float(line.split()[-1]) for line in f]
-        part = np.loadtxt(dirn+'partition_tab.out')
+        part = np.loadtxt(osp.join(dirn, 'partition_tab.out'))
         part.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
         err = np.abs(r_ri[:,3]-r_con[:,3])
         norm = np.dot(r_con[:,3],part[:,3])

--- a/salted/aims/get_ml_err.py
+++ b/salted/aims/get_ml_err.py
@@ -1,15 +1,18 @@
-import numpy as np
+import os
 import time
 import sys
+
+import numpy as np
+
 import inp
 
 def main():
     from salted.sys_utils import read_system
     spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
-    
+
     start_time = time.time()
 
-    dirname = inp.path2qm+inp.predict_data
+    dirname = os.path.join(inp.path2qm, inp.predict_data)
     av_err = 0
     errs = np.zeros(ndata)
     g = open('ml_maes','w+')

--- a/salted/aims/get_ml_err.py
+++ b/salted/aims/get_ml_err.py
@@ -1,7 +1,7 @@
 import os
 import time
 import sys
-import osp as osp
+import os.path as osp
 
 import numpy as np
 

--- a/salted/aims/get_ml_err.py
+++ b/salted/aims/get_ml_err.py
@@ -1,8 +1,11 @@
 import os
 import time
 import sys
+import osp as osp
 
 import numpy as np
+
+from salted.sys_utils import sort_grid_data
 
 import inp
 
@@ -12,24 +15,29 @@ def main():
 
     start_time = time.time()
 
-    dirname = os.path.join(inp.path2qm, inp.predict_data)
+    dirname = osp.join(inp.path2qm, inp.predict_data)
     av_err = 0
     errs = np.zeros(ndata)
-    g = open('ml_maes','w+')
+    g = open('ml_maes', 'w+')
     for i in range(1,ndata+1):
-        dirn = dirname+str(i)+'/'
-#        f = open(dirn+'rho_scf.out')
-#        r_con = [float(line.split()[-1]) for line in f]
-        r_con = np.loadtxt(dirn+'rho_scf.out')
-        r_con.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
-#        f = open(dirn+'rho_df.out')
-#        r_ri = [float(line.split()[-1]) for line in f]
-        r_ri = np.loadtxt(dirn+'rho_ml.out')
-        r_ri.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
-#        f = open(dirn+'partition_tab.out')
-#        part = [float(line.split()[-1]) for line in f]
-        part = np.loadtxt(dirn+'partition_tab.out')
-        part.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        dirn = osp.join(dirname, str(i))
+        # f = open(dirn+'rho_scf.out')
+        # r_con = [float(line.split()[-1]) for line in f]
+        # f = open(dirn+'rho_df.out')
+        # r_ri = [float(line.split()[-1]) for line in f]
+        # f = open(dirn+'partition_tab.out')
+        # part = [float(line.split()[-1]) for line in f]
+
+        r_con = np.loadtxt(osp.join(dirn, 'rho_scf.out'))
+        r_ri = np.loadtxt(osp.join(dirn, 'rho_ml.out'))
+        part = np.loadtxt(osp.join(dirn, 'partition_tab.out'))
+        # r_con.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # r_ri.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        # part.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
+        r_con = sort_grid_data(r_con)
+        r_ri = sort_grid_data(r_ri)
+        part = sort_grid_data(part)
+
         err = np.abs(r_ri[:,3]-r_con[:,3])
         norm = np.dot(r_con[:,3],part[:,3])
         int_err = np.dot(err,part[:,3])*100/norm
@@ -42,6 +50,7 @@ def main():
     sem = np.std(errs)/np.sqrt(ndata)
 
     print('% MAE =', av_err)
-#    print(round(time.time() - start_time,1),'seconds')
+    end_time = time.time()
+    print(f"time_cost = {end_time - start_time:.2f} s")
 
 main()

--- a/salted/aims/make_geoms.py
+++ b/salted/aims/make_geoms.py
@@ -1,15 +1,18 @@
-import inp
 import os
-from ase.io import read, write
 import argparse
+import os.path as osp
 
-def add_command_line_arguments_contraction(parsetext):
-    parser = argparse.ArgumentParser(description=parsetext)
+from ase.io import read, write
+
+import inp
+
+def add_command_line_arguments_contraction():
+    parser = argparse.ArgumentParser()
     parser.add_argument("-pr", "--predict", action='store_true', help="Prepare geometries for a true prediction")
     args = parser.parse_args()
     return args
 
-args = add_command_line_arguments_contraction("")
+args = add_command_line_arguments_contraction()
 predict = args.predict
 
 fname = inp.filename
@@ -18,15 +21,11 @@ if predict:
 else:
     datadir = "data/"
 
-if not os.path.exists(inp.path2qm):
-    os.mkdir(inp.path2qm)
-if not os.path.exists(inp.path2qm+datadir):
-    os.mkdir(inp.path2qm+datadir)
-dirpath = inp.path2qm+datadir+'geoms/'
-if not os.path.exists(dirpath):
-    os.mkdir(dirpath)
+dirpath = osp.join(inp.path2qm, datadir, "geoms")
+if not osp.exists(dirpath):
+    os.makedirs(dirpath)
 
 xyz_file = read(fname,":")
 n = len(xyz_file)
 for i in range(n):
-    write(dirpath+str(i+1)+'.in',xyz_file[i])
+    write(osp.join(dirpath, f"{i+1}.in"), xyz_file[i])

--- a/salted/aims/move_data.py
+++ b/salted/aims/move_data.py
@@ -70,9 +70,9 @@ for i in conf_range:
     t = t[idx]
     ovlp = ovlp[idx,:]
     ovlp = ovlp[:,idx]
-    np.save(osp.join(inp.saltedpath, f'overlaps/overlap_conf{i}.npy'), ovlp)
-    np.save(osp.join(inp.saltedpath, f'projections/projections_conf{i}.npy'), o)
-    np.save(osp.join(inp.saltedpath, f'coefficients/coefficients_conf{i}.npy'), t)
+    np.save(osp.join(inp.saltedpath, "overlaps", f"overlap_conf{i}.npy"), ovlp)
+    np.save(osp.join(inp.saltedpath, "projections", f"projections_conf{i}.npy"), o)
+    np.save(osp.join(inp.saltedpath, "coefficients", f"coefficients_conf{i}.npy"), t)
 
 if size > 1: comm.Barrier()
 

--- a/salted/aims/move_data.py
+++ b/salted/aims/move_data.py
@@ -1,5 +1,7 @@
-import numpy as np
 import os
+import os.path as osp
+
+import numpy as np
 import inp
 from ase.io import read
 
@@ -15,12 +17,14 @@ else:
     size = 1
 
 if (rank == 0):
-    if not os.path.exists(inp.saltedpath+"overlaps"):
-        os.mkdir(inp.saltedpath+"overlaps")
-    if not os.path.exists(inp.saltedpath+"coefficients"):
-        os.mkdir(inp.saltedpath+"coefficients")
-    if not os.path.exists(inp.saltedpath+"projections"):
-        os.mkdir(inp.saltedpath+"projections")
+    """check if all subdirectories exist, if not create them"""
+    sub_dirs = [
+        osp.join(inp.saltedpath, d)
+        for d in ("overlaps", "coefficients", "projections")
+    ]
+    for sub_dir in sub_dirs:
+        if not osp.exists(sub_dir):
+            os.mkdir(sub_dir)
 
 xyzfile = read(inp.filename,":")
 ndata = len(xyzfile)
@@ -42,37 +46,40 @@ else:
     conf_range = list(range(ndata))
 
 for i in conf_range:
-    dirpath = inp.path2qm+'data/'+str(i+1)+'/'
-    idx = np.loadtxt(dirpath+'idx_prodbas.out').astype(int)
-    cs_list = np.loadtxt(dirpath+'prodbas_condon_shotley_list.out').astype(int)
+    dirpath = osp.join(inp.path2qm, 'data', str(i+1))
+    idx = np.loadtxt(osp.join(dirpath, 'idx_prodbas.out')).astype(int)
+    cs_list = np.loadtxt(osp.join(dirpath, 'prodbas_condon_shotley_list.out')).astype(int)
     idx -= 1
     cs_list -= 1
     idx = list(idx)
     cs_list = list(cs_list)
-    o = np.loadtxt(dirpath+'ri_projections.out').reshape(-1)
-    t = np.loadtxt(dirpath+'ri_restart_coeffs_df.out').reshape(-1)
-    ovlp = np.loadtxt(dirpath+'ri_ovlp.out').reshape(-1)
-    
+    o = np.loadtxt(osp.join(dirpath, 'ri_projections.out')).reshape(-1)
+    t = np.loadtxt(osp.join(dirpath, 'ri_restart_coeffs_df.out')).reshape(-1)
+    ovlp = np.loadtxt(osp.join(dirpath, 'ri_ovlp.out')).reshape(-1)
+
     n = len(o)
     ovlp = ovlp.reshape(n,n)
-    
+
     for j in cs_list:
         ovlp[j,:] *= -1
         ovlp[:,j] *= -1
         o[j] *= -1
         t[j] *= -1
-    
+
     o = o[idx]
     t = t[idx]
     ovlp = ovlp[idx,:]
     ovlp = ovlp[:,idx]
-    np.save(inp.saltedpath+'overlaps/overlap_conf'+str(i)+'.npy',ovlp)
-    np.save(inp.saltedpath+'projections/projections_conf'+str(i)+'.npy',o)
-    np.save(inp.saltedpath+'coefficients/coefficients_conf'+str(i)+'.npy',t)
+    np.save(osp.join(inp.saltedpath, f'overlaps/overlap_conf{i}.npy'), ovlp)
+    np.save(osp.join(inp.saltedpath, f'projections/projections_conf{i}.npy'), o)
+    np.save(osp.join(inp.saltedpath, f'coefficients/coefficients_conf{i}.npy'), t)
 
 if size > 1: comm.Barrier()
 
+
+"""delte ri basis overlap and proj coeffs files"""
+
 for i in conf_range:
-    dirpath = inp.path2qm+'data/'+str(i+1)+'/'
-    os.remove(dirpath+'ri_ovlp.out')
-    os.remove(dirpath+'ri_projections.out')
+    dirpath = osp.join(inp.path2qm, 'data', str(i+1))
+    os.remove(osp.join(dirpath, 'ri_ovlp.out'))
+    os.remove(osp.join(dirpath, 'ri_projections.out'))

--- a/salted/aims/move_data_in.py
+++ b/salted/aims/move_data_in.py
@@ -9,18 +9,23 @@ from salted.sys_utils import read_system
 
 species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
 
-pdir = 'predictions_'+inp.saltedname+'_'+inp.predname+'/'
+pdir = f"predictions_{inp.saltedname}_{inp.predname}"
 
 M = inp.Menv
 ntrain = int(inp.trainfrac*inp.Ntrain)
 
 for i in range(ndata):
-    t = np.load(inp.saltedpath+pdir+"M"+str(M)+"_zeta"+str(inp.z)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(inp.regul)))+"/prediction_conf"+str(i)+".npy")
+    print(f"processing {i+1}/{ndata} frame")
+    t = np.load(os.path.join(
+        inp.saltedpath, pdir,
+        f"M{M}_zeta{inp.z}", f"N{ntrain}_reg{int(np.log10(inp.regul))}",
+        f"prediction_conf{i}.npy",
+    ))
     n = len(t)
 
-    dirpath = os.path.join(inp.path2qm, inp.predict_data, str(i+1))
+    dirpath = os.path.join(inp.path2qm, inp.predict_data, f"{i+1}")
 
-    idx = np.loadtxt(dirpath+'/idx_prodbas.out').astype(int)
+    idx = np.loadtxt(os.path.join(dirpath, f"idx_prodbas.out")).astype(int)
     idx -= 1
     idx = list(idx)
     idx_rev = []
@@ -28,7 +33,9 @@ for i in range(ndata):
         idx_rev.append(idx.index(i))
     #	np.savetxt('../idx_prodbas_rev.out',idx_rev)
     #	idx_rev = np.loadtxt('../idx_prodbas_rev.out').astype(int)
-    cs_list = np.loadtxt(dirpath+'/prodbas_condon_shotley_list.out').astype(int)
+    cs_list = np.loadtxt(os.path.join(
+        dirpath, f"prodbas_condon_shotley_list.out"
+    )).astype(int)
     cs_list -= 1
     cs_list = list(cs_list)
 
@@ -36,5 +43,5 @@ for i in range(ndata):
     for j in cs_list:
         t[j] *= -1
 
-    np.savetxt(dirpath+'/ri_restart_coeffs_predicted.out',t)
+    np.savetxt(os.path.join(dirpath, f"ri_restart_coeffs_predicted.out"), t)
 

--- a/salted/aims/move_data_in.py
+++ b/salted/aims/move_data_in.py
@@ -27,21 +27,33 @@ for i in range(ndata):
 
     idx = np.loadtxt(os.path.join(dirpath, f"idx_prodbas.out")).astype(int)
     idx -= 1
-    idx = list(idx)
-    idx_rev = []
-    for i in range(n):
-        idx_rev.append(idx.index(i))
+
+    # # old method
+    # idx = list(idx)
+    # idx_rev = []
+    # for i in range(n):
+    #     idx_rev.append(idx.index(i))
+
+    # accelerated method
+    idx_rev = np.empty_like(idx)
+    idx_rev[idx] = np.arange(len(idx))
+
     #	np.savetxt('../idx_prodbas_rev.out',idx_rev)
     #	idx_rev = np.loadtxt('../idx_prodbas_rev.out').astype(int)
     cs_list = np.loadtxt(os.path.join(
         dirpath, f"prodbas_condon_shotley_list.out"
     )).astype(int)
     cs_list -= 1
-    cs_list = list(cs_list)
 
+    # # old method
+    # cs_list = list(cs_list)
+    # t = t[idx_rev]
+    # for j in cs_list:
+    #     t[j] *= -1
+
+    # accelerated method
     t = t[idx_rev]
-    for j in cs_list:
-        t[j] *= -1
+    t[cs_list] *= -1
 
     np.savetxt(os.path.join(dirpath, f"ri_restart_coeffs_predicted.out"), t)
 

--- a/salted/aims/move_data_in.py
+++ b/salted/aims/move_data_in.py
@@ -1,9 +1,12 @@
-import numpy as np
+import os
 import sys
+
+import numpy as np
+
 import inp
 
 from salted.sys_utils import read_system
-    
+
 species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
 
 pdir = 'predictions_'+inp.saltedname+'_'+inp.predname+'/'
@@ -15,8 +18,8 @@ for i in range(ndata):
     t = np.load(inp.saltedpath+pdir+"M"+str(M)+"_zeta"+str(inp.z)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(inp.regul)))+"/prediction_conf"+str(i)+".npy")
     n = len(t)
 
-    dirpath = inp.path2qm+inp.predict_data+str(i+1)
-        
+    dirpath = os.path.join(inp.path2qm, inp.predict_data, str(i+1))
+
     idx = np.loadtxt(dirpath+'/idx_prodbas.out').astype(int)
     idx -= 1
     idx = list(idx)

--- a/salted/collect_matrices.py
+++ b/salted/collect_matrices.py
@@ -24,21 +24,21 @@ def build():
         return
 
     # load training set
-    trainrangetot = np.loadtxt(inp.saltedpath+rdir+"/training_set_N"+str(inp.Ntrain)+".txt",int)
+    trainrangetot = np.loadtxt(os.path.join(inp.saltedpath, rdir, f"training_set_N{inp.Ntrain}.txt"), int)
     ntrain = round(inp.trainfrac*inp.Ntrain)
     
     nblocks = int(ntrain/blocksize)
     print("blocksize =",blocksize)
     print("number of blocks = ",nblocks)
     
-    Avec = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Avec_N"+str(blocksize)+"_chunk0.npy")
-    Bmat = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Bmat_N"+str(blocksize)+"_chunk0.npy")
+    Avec = np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Avec_N{blocksize}_chunk0.npy"))
+    Bmat = np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Bmat_N{blocksize}_chunk0.npy"))
     for iblock in range(1,nblocks):
-        Avec += np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Avec_N"+str(blocksize)+"_chunk"+str(iblock)+".npy")
-        Bmat += np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Bmat_N"+str(blocksize)+"_chunk"+str(iblock)+".npy")
+        Avec += np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Avec_N{blocksize}_chunk{iblock}.npy"))
+        Bmat += np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Bmat_N{blocksize}_chunk{iblock}.npy"))
     
-    np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Avec_N"+str(ntrain)+".npy",Avec)
-    np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Bmat_N"+str(ntrain)+".npy",Bmat)
+    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", "Avec_N{ntrain}.npy", Avec))
+    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", "Bmat_N{ntrain}.npy", Bmat))
  
     return
 

--- a/salted/collect_matrices.py
+++ b/salted/collect_matrices.py
@@ -11,9 +11,9 @@ def build():
     blocksize = inp.blocksize
     
     if inp.field:
-        rdir = "regrdir_"+inp.saltedname+"_field"
+        rdir = f"regrdir_{inp.saltedname}_field"
     else:
-        rdir = "regrdir_"+inp.saltedname
+        rdir = f"regrdir_{inp.saltedname}"
     
     # sparse-GPR parameters
     M = inp.Menv
@@ -37,8 +37,8 @@ def build():
         Avec += np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Avec_N{blocksize}_chunk{iblock}.npy"))
         Bmat += np.load(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Bmat_N{blocksize}_chunk{iblock}.npy"))
     
-    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", "Avec_N{ntrain}.npy", Avec))
-    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", "Bmat_N{ntrain}.npy", Bmat))
+    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Avec_N{ntrain}.npy", Avec))
+    np.save(os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Bmat_N{ntrain}.npy", Bmat))
  
     return
 

--- a/salted/equipred.py
+++ b/salted/equipred.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import time
+import os.path as osp
+
 import h5py
 import numpy as np
 from scipy import special
@@ -11,8 +13,8 @@ from rascaline import SphericalExpansion
 from rascaline import LodeSphericalExpansion
 from metatensor import Labels
 
-from salted.lib import equicomb 
-from salted.lib import equicombfield 
+from salted.lib import equicomb
+from salted.lib import equicombfield
 
 from salted import sph_utils
 from salted import basis
@@ -39,7 +41,7 @@ def build():
     filename = inp.filename
     saltedname = inp.saltedname
     predname = inp.predname
-    rep1 = inp.rep1 
+    rep1 = inp.rep1
     rcut1 = inp.rcut1
     sig1 = inp.sig1
     nrad1 = inp.nrad1
@@ -52,37 +54,37 @@ def build():
     nang2 = inp.nang2
     neighspe2 = inp.neighspe2
     ncut = inp.ncut
-    
+
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system(filename)
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
+
     bohr2angs = 0.529177210670
-    
-    # Kernel parameters 
+
+    # Kernel parameters
     M = inp.Menv
     zeta = inp.z
     reg = inp.regul
-    
+
     # Distribute structures to tasks
     ndata_true = ndata
     if inp.parallel:
         conf_range = get_conf_range(rank,size,ndata,list(range(ndata)))
         conf_range = comm.scatter(conf_range,root=0)
         ndata = len(conf_range)
-        print('Task',rank+1,'handles the following structures:',conf_range,flush=True)
+        print(f"Task {rank+1} handles the following structures: {conf_range}", flush=True)
     else:
         conf_range = list(range(ndata))
     natoms_total = sum(natoms[conf_range])
-    
+
     if inp.qmcode=="cp2k":
-    
+
         # get basis set info from CP2K BASIS_LRIGPW_AUXMOLOPT
         if rank == 0: print("Reading auxiliary basis info...")
         alphas = {}
         sigmas = {}
         for spe in species:
             for l in range(lmax[spe]+1):
-                avals = np.loadtxt(spe+"-"+inp.dfbasis+"-alphas-L"+str(l)+".dat")
+                avals = np.loadtxt(f"{spe}-{inp.dfbasis}-alphas-L{l}.dat")
                 if nmax[(spe,l)]==1:
                     alphas[(spe,l,0)] = float(avals)
                     sigmas[(spe,l,0)] = np.sqrt(0.5/alphas[(spe,l,0)]) # bohr
@@ -90,7 +92,7 @@ def build():
                     for n in range(nmax[(spe,l)]):
                         alphas[(spe,l,n)] = avals[n]
                         sigmas[(spe,l,n)] = np.sqrt(0.5/alphas[(spe,l,n)]) # bohr
-        
+
         # compute integrals of basis functions (needed to a posteriori correction of the charge)
         charge_integrals = {}
         dipole_integrals = {}
@@ -104,10 +106,10 @@ def build():
                     dipole_radint = 2**float(1.0+float(l)/2.0) * sigmas[(spe,l,n)]**(4+l) * special.gamma(2.0+float(l)/2.0)
                     charge_integrals[(spe,l,n)] = charge_radint * np.sqrt(4.0*np.pi) / np.sqrt(inner)
                     dipole_integrals[(spe,l,n)] = dipole_radint * np.sqrt(4.0*np.pi/3.0) / np.sqrt(inner)
-    
+
     loadstart = time.time()
-    
-    # Load training feature vectors and RKHS projection matrix 
+
+    # Load training feature vectors and RKHS projection matrix
     Mspe = {}
     power_env_sparse = {}
     if inp.field: power_env_sparse_field = {}
@@ -116,34 +118,56 @@ def build():
     if inp.field: vfps_field = {}
     for lam in range(lmax_max+1):
         # Load sparsification details
-        if ncut > -1: vfps[lam] = np.load(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+".npy")
-        if ncut > -1 and inp.field: vfps_field[lam] = np.load(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+"_field.npy")
+        if ncut > -1:
+            vfps_field[lam] = np.load(osp.join(
+                inp.saltedpath,
+                f"equirepr_{saltedname}",
+                f"fps{ncut}-{lam}_field.npy" if inp.field else f"fps{ncut}-{lam}.npy"
+            ))
         for spe in species:
-            # load sparse equivariant descriptors 
-            power_env_sparse[(lam,spe)] = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+"-M-"+str(M)+".h5",'r')[spe][:]
-            if inp.field: power_env_sparse_field[(lam,spe)] = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+"-M-"+str(M)+"_field.h5",'r')[spe][:]
-            if lam == 0: Mspe[spe] = power_env_sparse[(lam,spe)].shape[0]
-            # load RKHS projectors 
+            # load sparse equivariant descriptors
+            power_env_sparse[(lam,spe)] = h5py.File(osp.join(
+                inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}-M-{M}.h5"
+            ), 'r')[spe][:]
             if inp.field:
-                Vmat[(lam,spe)] = np.load(inp.saltedpath+"kernels_"+saltedname+"_field/spe"+str(spe)+"_l"+str(lam)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
-            else:
-                Vmat[(lam,spe)] = np.load(inp.saltedpath+"kernels_"+saltedname+"/spe"+str(spe)+"_l"+str(lam)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
-            # precompute projection on RKHS if linear model 
+                power_env_sparse_field[(lam,spe)] = h5py.File(osp.join(
+                    inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}-M-{M}_field.h5"
+                ), 'r')[spe][:]
+            if lam == 0:
+                Mspe[spe] = power_env_sparse[(lam,spe)].shape[0]
+            # load RKHS projectors
+            Vmat[(lam,spe)] = np.load(osp.join(
+                inp.saltedpath,
+                f"kernels_{saltedname}_field" if inp.field else f"kernels_{saltedname}",
+                f"spe{spe}_l{lam}",
+                f"M{M}_zeta{zeta}",
+                f"projector.npy",
+            ))
+            # precompute projection on RKHS if linear model
             if zeta==1:
-                power_env_sparse[(lam,spe)] = np.dot(Vmat[(lam,spe)].T,power_env_sparse[(lam,spe)])
-                if inp.field: power_env_sparse_field[(lam,spe)] = np.dot(Vmat[(lam,spe)].T,power_env_sparse_field[(lam,spe)])
-    
+                power_env_sparse[(lam,spe)] = np.dot(
+                    Vmat[(lam,spe)].T, power_env_sparse[(lam,spe)]
+                )
+                if inp.field:
+                    power_env_sparse_field[(lam,spe)] = np.dot(
+                        Vmat[(lam,spe)].T, power_env_sparse_field[(lam,spe)]
+                    )
+
+    reg_log10_intstr = str(int(np.log10(reg)))  # for consistency
+
     # load regression weights
     ntrain = int(inp.Ntrain*inp.trainfrac)
-    if inp.field:
-        weights = np.load(inp.saltedpath+"regrdir_"+saltedname+"_field/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+".npy")
-    else:
-        weights = np.load(inp.saltedpath+"regrdir_"+saltedname+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+".npy")
-    
-    if rank == 0: print("load time:", (time.time()-loadstart))
-    
+    weights = np.load(osp.join(
+        inp.saltedpath,
+        f"regrdir_{saltedname}_field" if inp.field else f"regrdir_{saltedname}",
+        f"M{M}_zeta{zeta}",
+        f"weights_N{ntrain}_reg{reg_log10_intstr}.npy"
+    ))
+
+    if rank == 0:  print(f"load time: {(time.time()-loadstart):.2f} s")
+
     start = time.time()
-    
+
     HYPER_PARAMETERS_DENSITY = {
         "cutoff": rcut1,
         "max_radial": nrad1,
@@ -153,7 +177,7 @@ def build():
         "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
         "cutoff_function": {"ShiftedCosine": {"width": 0.1}},
     }
-    
+
     HYPER_PARAMETERS_POTENTIAL = {
         "potential_exponent": 1,
         "cutoff": rcut2,
@@ -163,25 +187,28 @@ def build():
         "center_atom_weight": 1.0,
         "radial_basis": {"Gto": {"spline_accuracy": 1e-6}}
     }
-    
+
     frames = read(filename,":")
     frames = [frames[i] for i in conf_range]
-    
+
     if rank == 0: print(f"The dataset contains {ndata_true} frames.")
-    
+
     if rep1=="rho":
-        # get SPH expansion for atomic density    
+        # get SPH expansion for atomic density
         calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
-    
+
     elif rep1=="V":
-        # get SPH expansion for atomic potential 
+        # get SPH expansion for atomic potential
         calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
-    
+
     else:
-        if rank == 0: print("Error: requested representation", rep1, "not provided")
-    
+        if rank == 0:
+            raise ValueError(f"Unknown representation {rep1=}, expected 'rho' or 'V'")
+        else:
+            exit()
+
     descstart = time.time()
-    
+
     nspe1 = len(neighspe1)
     keys_array = np.zeros(((nang1+1)*len(species)*nspe1,3),int)
     i = 0
@@ -190,33 +217,36 @@ def build():
             for speneigh in neighspe1:
                 keys_array[i] = np.array([l,atomic_numbers[specen],atomic_numbers[speneigh]],int)
                 i += 1
-    
+
     keys_selection = Labels(
         names=["spherical_harmonics_l","species_center","species_neighbor"],
         values=keys_array
     )
-    
+
     spx = calculator.compute(frames, selected_keys=keys_selection)
     spx = spx.keys_to_properties("species_neighbor")
     spx = spx.keys_to_samples("species_center")
-    
+
     # Get 1st set of coefficients as a complex numpy array
     omega1 = np.zeros((nang1+1,natoms_total,2*nang1+1,nspe1*nrad1),complex)
     for l in range(nang1+1):
         c2r = sph_utils.complex_to_real_transformation([2*l+1])[0]
         omega1[l,:,:2*l+1,:] = np.einsum('cr,ard->acd',np.conj(c2r.T),spx.block(spherical_harmonics_l=l).values)
-    
+
     if rep2=="rho":
-        # get SPH expansion for atomic density    
+        # get SPH expansion for atomic density
         calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
-    
+
     elif rep2=="V":
-        # get SPH expansion for atomic potential 
-        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL) 
-    
+        # get SPH expansion for atomic potential
+        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+
     else:
-        if rank == 0: print("Error: requested representation", rep2, "not provided")
-    
+        if rank == 0:
+            raise ValueError(f"Unknown representation {rep2=}, expected 'rho' or 'V'")
+        else:
+            exit()
+
     nspe2 = len(neighspe2)
     keys_array = np.zeros(((nang2+1)*len(species)*nspe2,3),int)
     i = 0
@@ -225,52 +255,53 @@ def build():
             for speneigh in neighspe2:
                 keys_array[i] = np.array([l,atomic_numbers[specen],atomic_numbers[speneigh]],int)
                 i += 1
-    
+
     keys_selection = Labels(
         names=["spherical_harmonics_l","species_center","species_neighbor"],
         values=keys_array
     )
-    
+
     spx_pot = calculator.compute(frames, selected_keys=keys_selection)
     spx_pot = spx_pot.keys_to_properties("species_neighbor")
     spx_pot = spx_pot.keys_to_samples("species_center")
-    
-    # Get 2nd set of coefficients as a complex numpy array 
+
+    # Get 2nd set of coefficients as a complex numpy array
     omega2 = np.zeros((nang2+1,natoms_total,2*nang2+1,nspe2*nrad2),complex)
     for l in range(nang2+1):
         c2r = sph_utils.complex_to_real_transformation([2*l+1])[0]
         omega2[l,:,:2*l+1,:] = np.einsum('cr,ard->acd',np.conj(c2r.T),spx_pot.block(spherical_harmonics_l=l).values)
-    
+
     if inp.field:
-    # get SPH expansion for a uniform and constant external field aligned along Z 
+    # get SPH expansion for a uniform and constant external field aligned along Z
         omega_field = np.zeros((natoms_total,nrad2),complex)
         for iat in range(natoms_total):
             omega_field[iat] = efield.get_efield_sph(nrad2,rcut2)
-    
-    if rank == 0: print("coefficients time:", (time.time()-descstart))
-    if rank == 0: print("")
-    
-    dirpath = os.path.join(inp.saltedpath,"predictions_"+saltedname)
-    if inp.field: dirpath += '_field'
-    dirpath += '_'+predname
-    if rank == 0 and not os.path.exists(dirpath):
-        os.mkdir(dirpath)
-    dirpath = os.path.join(dirpath,"M"+str(M)+"_zeta"+str(zeta))
-    if rank == 0 and not os.path.exists(dirpath):
-        os.mkdir(dirpath)
-    dirpath = os.path.join(dirpath,"N"+str(ntrain)+"_reg"+str(int(np.log10(reg))))
-    if rank == 0 and not os.path.exists(dirpath):
-        os.mkdir(dirpath)
-    if size > 1: comm.Barrier()
-    
+
+    if rank == 0: print(f"coefficients time: {(time.time()-descstart):.2f} s\n")
+
+    # base directory path for this prediction
+    dirpath = osp.join(
+        inp.saltedpath,
+        f"predictions_{saltedname}_field_{predname}" \
+            if inp.field else f"predictions_{saltedname}_{predname}",
+        f"M{M}_zeta{zeta}",
+        f"N{ntrain}_reg{reg_log10_intstr}",
+    )
+
+    # Create directory for predictions
+    if rank == 0:
+        if not os.path.exists(dirpath):
+            os.makedirs(dirpath)
+    if size > 1:  comm.Barrier()
+
     # Compute equivariant descriptors for each lambda value entering the SPH expansion of the electron density
     psi_nm = {}
     for lam in range(lmax_max+1):
-    
-        if rank == 0: print("lambda =", lam)
-    
+
+        if rank == 0: print(f"lambda = {lam}")
+
         equistart = time.time()
-    
+
         # Select relevant angular components for equivariant descriptor calculation
         llmax = 0
         lvalues = {}
@@ -283,139 +314,143 @@ def build():
                         llmax+=1
         # Fill dense array from dictionary
         llvec = np.zeros((llmax,2),int)
-        for il in range(llmax): 
+        for il in range(llmax):
             llvec[il,0] = lvalues[il][0]
             llvec[il,1] = lvalues[il][1]
-        
+
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
-        wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_lmax2-"+str(nang2)+".dat")
+        wigner3j = np.loadtxt(osp.join(
+            inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"
+        ))
         wigdim = wigner3j.size
-      
-        # Reshape arrays of expansion coefficients for optimal Fortran indexing 
+
+        # Reshape arrays of expansion coefficients for optimal Fortran indexing
         v1 = np.transpose(omega1,(2,0,3,1))
         v2 = np.transpose(omega2,(2,0,3,1))
-    
+
         # Compute complex to real transformation matrix for the given lambda value
         c2r = sph_utils.complex_to_real_transformation([2*lam+1])[0]
-    
+
         # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018)
         p = equicomb.equicomb(natoms_total,nang1,nang2,nspe1*nrad1,nspe2*nrad2,v1,v2,wigdim,wigner3j,llmax,llvec.T,lam,c2r)
-    
+
         # Define feature space and reshape equivariant descriptor
         featsize = nspe1*nspe2*nrad1*nrad2*llmax
         p = np.transpose(p,(4,0,1,2,3)).reshape(natoms_total,2*lam+1,featsize)
-     
-        if rank == 0: print("equivariant time:", (time.time()-equistart))
-        
+
+        if rank == 0: print(f"equivariant time: {(time.time()-equistart):.2f} s")
+
         normstart = time.time()
-        
-        # Normalize equivariant descriptor  
+
+        # Normalize equivariant descriptor
         inner = np.einsum('ab,ab->a', p.reshape(natoms_total,(2*lam+1)*featsize),p.reshape(natoms_total,(2*lam+1)*featsize))
         p = np.einsum('abc,a->abc', p,1.0/np.sqrt(inner))
-        
-        if rank == 0: print("norm time:", (time.time()-normstart))
-    
+
+        if rank == 0: print(f"norm time: {(time.time()-normstart):.2f} s")
+
         sparsestart = time.time()
-        
+
         if ncut > -1:
             p = p.reshape(natoms_total*(2*lam+1),featsize)
             p = p.T[vfps[lam]].T
             featsize = inp.ncut
-        
-        if rank == 0: print("sparse time:", (time.time()-sparsestart))
-        
+
+        if rank == 0: print(f"sparse time: {(time.time()-sparsestart):.2f} s")
+
         fillstart = time.time()
-    
-        # Fill vector of equivariant descriptor 
+
+        # Fill vector of equivariant descriptor
         if lam==0:
             p = p.reshape(natoms_total,featsize)
             pvec = np.zeros((ndata,natmax,featsize))
         else:
             p = p.reshape(natoms_total,2*lam+1,featsize)
             pvec = np.zeros((ndata,natmax,2*lam+1,featsize))
-    
+
         j = 0
         for i,iconf in enumerate(conf_range):
             for iat in range(natoms[iconf]):
                 pvec[i,iat] = p[j]
                 j += 1
-        
-        if rank == 0: print("fill vector time:", (time.time()-fillstart))
-    
+
+        if rank == 0: print(f"fill vector time: {(time.time()-fillstart):.2f} s")
+
         if inp.field:
-             #########################################################
-             #                 START E-FIELD HERE
-             #########################################################
-          
-             # Select relevant angular components for equivariant descriptor calculation
-             llmax = 0
-             lvalues = {}
-             for l1 in range(nang1+1):
-                 # keep only even combination to enforce inversion symmetry
-                 if (lam+l1+1)%2==0 :
-                     if abs(1-lam) <= l1 and l1 <= (1+lam) :
-                         lvalues[llmax] = [l1,1]
-                         llmax+=1
-             # Fill dense array from dictionary
-             llvec = np.zeros((llmax,2),int)
-             for il in range(llmax):
-                 llvec[il,0] = lvalues[il][0]
-                 llvec[il,1] = lvalues[il][1]
-    
-             # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
-             wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_field.dat")
-             wigdim = wigner3j.size
-          
-             # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018)
-             v2 = omega_field.T
-             p = equicombfield.equicombfield(natoms_total,nang1,nspe1*nrad1,nrad2,v1,v2,wigdim,wigner3j,llmax,llvec.T,lam,c2r)
-     
-             # Define feature space and reshape equivariant descriptor
-             featsizefield = nspe1*nrad1*nrad2*llmax
-             p = np.transpose(p,(4,0,1,2,3)).reshape(natoms_total,2*lam+1,featsizefield)
-           
-             if rank == 0: print("field equivariant time:", (time.time()-equistart))
-              
-             normstart = time.time()
-     
-             # Normalize equivariant descriptor  
-             inner = np.einsum('ab,ab->a', p.reshape(natoms_total,(2*lam+1)*featsizefield),p.reshape(natoms_total,(2*lam+1)*featsizefield))
-             p = np.einsum('abc,a->abc', p,1.0/np.sqrt(inner))
-        
-             if rank == 0: print("field norm time:", (time.time()-normstart))
-    
-             if ncut > -1:
-                 p = p.reshape(natoms_total*(2*lam+1),featsizefield)
-                 p = p.T[vfps_field[lam]].T
-                 featsizefield = inp.ncut 
-    
-             fillstart = time.time()
-     
-             # Fill vector of equivariant descriptor 
-             if lam==0:
-                 p = p.reshape(natoms_total,featsizefield)
-                 pvec_field = np.zeros((ndata,natmax,featsizefield))
-             else:
-                 p = p.reshape(natoms_total,2*lam+1,featsizefield)
-                 pvec_field = np.zeros((ndata,natmax,2*lam+1,featsizefield))
-    
-             j = 0
-             for i,iconf in enumerate(conf_range):
-                 for iat in range(natoms[iconf]):
-                     pvec_field[i,iat] = p[j]
-                     j += 1
-             
+            #########################################################
+            #                 START E-FIELD HERE
+            #########################################################
+
+            # Select relevant angular components for equivariant descriptor calculation
+            llmax = 0
+            lvalues = {}
+            for l1 in range(nang1+1):
+                # keep only even combination to enforce inversion symmetry
+                if (lam+l1+1)%2==0 :
+                    if abs(1-lam) <= l1 and l1 <= (1+lam) :
+                        lvalues[llmax] = [l1,1]
+                        llmax+=1
+            # Fill dense array from dictionary
+            llvec = np.zeros((llmax,2),int)
+            for il in range(llmax):
+                llvec[il,0] = lvalues[il][0]
+                llvec[il,1] = lvalues[il][1]
+
+            # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
+            wigner3j = np.loadtxt(osp.join(
+                inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_field.dat"
+            ))
+            wigdim = wigner3j.size
+
+            # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018)
+            v2 = omega_field.T
+            p = equicombfield.equicombfield(natoms_total,nang1,nspe1*nrad1,nrad2,v1,v2,wigdim,wigner3j,llmax,llvec.T,lam,c2r)
+
+            # Define feature space and reshape equivariant descriptor
+            featsizefield = nspe1*nrad1*nrad2*llmax
+            p = np.transpose(p,(4,0,1,2,3)).reshape(natoms_total,2*lam+1,featsizefield)
+
+            if rank == 0: print(f"field equivariant time: {(time.time()-equistart):.2f} s")
+
+            normstart = time.time()
+
+            # Normalize equivariant descriptor
+            inner = np.einsum('ab,ab->a', p.reshape(natoms_total,(2*lam+1)*featsizefield),p.reshape(natoms_total,(2*lam+1)*featsizefield))
+            p = np.einsum('abc,a->abc', p,1.0/np.sqrt(inner))
+
+            if rank == 0: print(f"field norm time: {(time.time()-normstart):.2f} s")
+
+            if ncut > -1:
+                p = p.reshape(natoms_total*(2*lam+1),featsizefield)
+                p = p.T[vfps_field[lam]].T
+                featsizefield = inp.ncut
+
+            fillstart = time.time()
+
+            # Fill vector of equivariant descriptor
+            if lam==0:
+                p = p.reshape(natoms_total,featsizefield)
+                pvec_field = np.zeros((ndata,natmax,featsizefield))
+            else:
+                p = p.reshape(natoms_total,2*lam+1,featsizefield)
+                pvec_field = np.zeros((ndata,natmax,2*lam+1,featsizefield))
+
+            j = 0
+            for i,iconf in enumerate(conf_range):
+                for iat in range(natoms[iconf]):
+                    pvec_field[i,iat] = p[j]
+                    j += 1
+
         rkhsstart = time.time()
- 
+
         if lam==0:
-    
-            if zeta==1: 
+
+            if zeta==1:
                  # Compute scalar kernels
                  kernel0_nm = {}
                  for i,iconf in enumerate(conf_range):
                      for spe in species:
-                         if inp.field: 
-                             psi_nm[(iconf,spe,lam)] = np.dot(pvec_field[i,atom_idx[(iconf,spe)]],power_env_sparse_field[(lam,spe)].T) 
+                         if inp.field:
+                             psi_nm[(iconf,spe,lam)] = np.dot(pvec_field[i,atom_idx[(iconf,spe)]],power_env_sparse_field[(lam,spe)].T)
                          else:
                              psi_nm[(iconf,spe,lam)] = np.dot(pvec[i,atom_idx[(iconf,spe)]],power_env_sparse[(lam,spe)].T)
             else:
@@ -429,19 +464,19 @@ def build():
                          else:
                              kernel_nm = kernel0_nm[(iconf,spe)]**zeta
                          # Project on RKHS
-                         psi_nm[(iconf,spe,lam)] = np.dot(kernel_nm,Vmat[(lam,spe)])    
- 
+                         psi_nm[(iconf,spe,lam)] = np.dot(kernel_nm,Vmat[(lam,spe)])
+
         else:
-  
-            if zeta==1: 
+
+            if zeta==1:
                 # Compute covariant kernels
                 for i,iconf in enumerate(conf_range):
                     for spe in species:
-                        if inp.field: 
+                        if inp.field:
                             psi_nm[(iconf,spe,lam)] = np.dot(pvec_field[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*lam+1),pvec_field.shape[-1]),power_env_sparse_field[(lam,spe)].T)
                         else:
                             psi_nm[(iconf,spe,lam)] = np.dot(pvec[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*lam+1),featsize),power_env_sparse[(lam,spe)].T)
-            else: 
+            else:
                 # Compute covariant kernels
                 for i,iconf in enumerate(conf_range):
                     for spe in species:
@@ -454,35 +489,40 @@ def build():
                                 kernel_nm[i1*(2*lam+1):i1*(2*lam+1)+2*lam+1][:,i2*(2*lam+1):i2*(2*lam+1)+2*lam+1] *= kernel0_nm[(iconf,spe)][i1,i2]**(zeta-1)
                         # Project on RKHS
                         psi_nm[(iconf,spe,lam)] = np.dot(kernel_nm,Vmat[(lam,spe)])
-    
+
         if rank == 0: print("rkhs time:", time.time()-rkhsstart,flush=True)
-    
+
     predstart = time.time()
-    
+
     if inp.qmcode=="cp2k":
         xyzfile = read(filename,":")
-        if rank == 0 and os.path.exists(dirpath+"/charges.dat"): os.remove(dirpath+"/charges.dat")
-        if rank == 0 and os.path.exists(dirpath+"/dipoles.dat"): os.remove(dirpath+"/dipoles.dat")
+        q_fpath = osp.join(dirpath, "charges.dat")
+        d_fpath = osp.join(dirpath, "dipoles.dat")
+        if rank == 0:
+            # remove old output files
+            remove_if_exists = lambda fpath: os.remove(fpath) if os.path.exists(fpath) else None
+            remove_if_exists(q_fpath)
+            remove_if_exists(d_fpath)
         if inp.parallel: comm.Barrier()
-        qfile = open(dirpath+"/charges.dat","a")
-        dfile = open(dirpath+"/dipoles.dat","a")
-    
+        qfile = open(q_fpath, "a")
+        dfile = open(d_fpath, "a")
+
     # Load spherical averages if required
     if inp.average:
         av_coefs = {}
         for spe in species:
-            av_coefs[spe] = np.load("averages_"+str(spe)+".npy")
-    
+            av_coefs[spe] = np.load(f"averages_{spe}.npy")
+
     # Perform equivariant predictions
     for iconf in conf_range:
-    
+
         Tsize = 0
         for iat in range(natoms[iconf]):
             spe = atomic_symbols[iconf][iat]
             for l in range(lmax[spe]+1):
                 for n in range(nmax[(spe,l)]):
                     Tsize += 2*l+1
-    
+
         # compute predictions per channel
         C = {}
         ispe = {}
@@ -494,11 +534,11 @@ def build():
                     Mcut = psi_nm[(iconf,spe,l)].shape[1]
                     C[(spe,l,n)] = np.dot(psi_nm[(iconf,spe,l)],weights[isize:isize+Mcut])
                     isize += Mcut
-    
+
         # init averages array if asked
         if inp.average:
             Av_coeffs = np.zeros(Tsize)
-        
+
         # fill vector of predictions
         i = 0
         pred_coefs = np.zeros(Tsize)
@@ -511,13 +551,13 @@ def build():
                         Av_coeffs[i] = av_coefs[spe][n]
                     i += 2*l+1
             ispe[spe] += 1
-    
+
         # add back spherical averages if required
         if inp.average:
             pred_coefs += Av_coeffs
-    
+
         if inp.qmcode=="cp2k":
-    
+
             # get geometry ingormation for dipole calculation
             geom = xyzfile[iconf]
             geom.wrap()
@@ -525,7 +565,7 @@ def build():
             cell = geom.get_cell()/bohr2angs
             all_symbols = xyzfile[iconf].get_chemical_symbols()
             all_natoms = int(len(all_symbols))
-    
+
             # compute integral of predicted density
             iaux = 0
             rho_int = 0.0
@@ -539,8 +579,8 @@ def build():
                             if l==0:
                                 rho_int += charge_integrals[(spe,l,n)] * pred_coefs[iaux]
                             iaux += 2*l+1
-    
-            # compute charge and dipole 
+
+            # compute charge and dipole
             iaux = 0
             charge = 0.0
             charge_right = 0.0
@@ -566,30 +606,30 @@ def build():
                                iaux += 1
             print(iconf+1,dipole,file=dfile)
             print(iconf+1,rho_int,charge,file=qfile)
-    
+
             # save predicted coefficients in CP2K format
-            np.savetxt(dirpath+"/COEFFS-"+str(iconf+1)+".dat",pred_coefs)
-    
+            np.savetxt(osp.join(dirpath, f"COEFFS-{iconf+1}.dat"), pred_coefs)
+
         # save predicted coefficients
-        np.save(dirpath+"/prediction_conf"+str(iconf)+".npy",pred_coefs)
-    
-    
+        np.save(osp.join(dirpath, f"prediction_conf{iconf}.npy"), pred_coefs)
+
+
     if inp.qmcode=="cp2k":
         qfile.close()
         dfile.close()
         if inp.parallel and rank == 0:
-            dips = np.loadtxt(dirpath+'/dipoles.dat')
-            np.savetxt(dirpath+'/dipoles.dat',dips[dips[:,0].argsort()],fmt='%i %f')
-            qs = np.loadtxt(dirpath+'/charges.dat')
-            np.savetxt(dirpath+'/charges.dat',qs[qs[:,0].argsort()],fmt='%i %f')
-    
-    if rank == 0: print("")
-    if rank == 0: print("prediction time:", time.time()-predstart)
-    
-    if rank == 0: print("")
-    if rank == 0: print("total time:", (time.time()-start))
+            d_fpath = osp.join(dirpath, "dipoles.dat")
+            dips = np.loadtxt(d_fpath)
+            np.savetxt(d_fpath, dips[dips[:,0].argsort()], fmt='%i %f')
+            q_fpath = osp.join(dirpath, "charges.dat")
+            qs = np.loadtxt(q_fpath)
+            np.savetxt(q_fpath, qs[qs[:,0].argsort()],fmt='%i %f')
 
-    return
+    if rank == 0:
+        print(f"\nprediction time: {(time.time()-predstart):.2f} s")
+        print(f"\ntotal time: {(time.time()-start):.2f} s")
+
+
 
 if __name__ == "__main__":
     build()

--- a/salted/equirepr.py
+++ b/salted/equirepr.py
@@ -1,12 +1,13 @@
 import os
+import random
 import sys
 import time
-from ase.data import atomic_numbers
-from ase.io import read
+import os.path as osp
+
 import numpy as np
 import h5py
-import random
-
+from ase.data import atomic_numbers
+from ase.io import read
 from rascaline import SphericalExpansion
 from rascaline import LodeSphericalExpansion
 from metatensor import Labels
@@ -19,13 +20,26 @@ from salted import basis
 from salted.lib import equicomb
 from salted.lib import equicombfield
 
+
+
 def build():
 
     sys.path.insert(0, './')
     import inp
 
+    if inp.parallel:
+        from mpi4py import MPI
+        # MPI information
+        comm = MPI.COMM_WORLD
+        size = comm.Get_size()
+        rank = comm.Get_rank()
+    #    print('This is task',rank+1,'of',size)
+    else:
+        rank = 0
+        size = 1
+
     if inp.sparsify:
-        
+
         if inp.ncut > 0:
 
             if inp.field:
@@ -37,8 +51,8 @@ def build():
 
             if rank==0: print("ERROR: features cutoff ncut must be a positive integer!")
             sys.exit(0)
-    
-    else: 
+
+    else:
 
         if inp.field:
             equirepr(sparsify=False,field=True)
@@ -51,7 +65,7 @@ def build():
 def equirepr(sparsify,field):
     sys.path.insert(0, './')
     import inp
-    
+
     filename = inp.filename
     saltedname = inp.saltedname
     rep1 = inp.rep1
@@ -69,7 +83,7 @@ def equirepr(sparsify,field):
     ncut = inp.ncut
     parallel = inp.parallel
     nsamples = inp.nsamples
-    
+
     if inp.parallel:
         from mpi4py import MPI
         # MPI information
@@ -80,13 +94,13 @@ def equirepr(sparsify,field):
     else:
         rank = 0
         size = 1
-    
+
     from salted.sys_utils import read_system, get_atom_idx,get_conf_range
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
+
     start = time.time()
-   
+
     if nsamples < ndata and sparsify: ndata = inp.nsamples
     ndata_true = ndata
     if inp.parallel:
@@ -96,12 +110,12 @@ def equirepr(sparsify,field):
         ndata = len(conf_range)
     else:
         conf_range = list(range(ndata))
-    
+
     natoms_total = sum(natoms[conf_range])
-    
-    def do_fps(x, d=0,initial=-1):
+
+    def do_fps(x, d=0, initial=-1):
         # Code from Giulio Imbalzano
-    
+
         if d == 0 : d = len(x)
         n = len(x)
         iy = np.zeros(d,int)
@@ -119,7 +133,7 @@ def equirepr(sparsify,field):
             nd = n2 + n2[iy[i]] - 2*np.real(np.dot(x,np.conj(x[iy[i]])))
             dl = np.minimum(dl,nd)
         return iy
-    
+
     HYPER_PARAMETERS_DENSITY = {
         "cutoff": rcut1,
         "max_radial": nrad1,
@@ -129,7 +143,7 @@ def equirepr(sparsify,field):
         "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
         "cutoff_function": {"ShiftedCosine": {"width": 0.1}},
     }
-    
+
     HYPER_PARAMETERS_POTENTIAL = {
         "potential_exponent": 1,
         "cutoff": rcut2,
@@ -139,24 +153,24 @@ def equirepr(sparsify,field):
         "center_atom_weight": 1.0,
         "radial_basis": {"Gto": {"spline_accuracy": 1e-6}}
     }
-    
+
     frames = read(filename,":")
     if sparsify: random.Random(3).shuffle(frames)
     frames = [frames[i] for i in conf_range]
-    
+
     if rank == 0: print(f"The dataset contains {ndata_true} frames.")
-    
+
     if rep1=="rho":
-        # get SPH expansion for atomic density    
+        # get SPH expansion for atomic density
         calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
-    
+
     elif rep1=="V":
-        # get SPH expansion for atomic potential 
+        # get SPH expansion for atomic potential
         calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
-    
+
     else:
         print("Error: requested representation", rep1, "not provided")
-    
+
     nspe1 = len(neighspe1)
     keys_array = np.zeros(((nang1+1)*len(species)*nspe1,3),int)
     i = 0
@@ -165,49 +179,49 @@ def equirepr(sparsify,field):
             for speneigh in neighspe1:
                 keys_array[i] = np.array([l,atomic_numbers[specen],atomic_numbers[speneigh]],int)
                 i += 1
-    
+
     keys_selection = Labels(
         names=["spherical_harmonics_l","species_center","species_neighbor"],
         values=keys_array
     )
-    
+
     rhostart = time.time()
-    
+
     spx = calculator.compute(frames, selected_keys=keys_selection)
     spx = spx.keys_to_properties("species_neighbor")
     spx = spx.keys_to_samples("species_center")
-     
+
     # Get 1st set of coefficients as a complex numpy array
     omega1 = np.zeros((nang1+1,natoms_total,2*nang1+1,nspe1*nrad1),complex)
     for l in range(nang1+1):
         c2r = sph_utils.complex_to_real_transformation([2*l+1])[0]
         omega1[l,:,:2*l+1,:] = np.einsum('cr,ard->acd',np.conj(c2r.T),spx.block(spherical_harmonics_l=l).values)
-    
-    if rank == 0: print("rho time:", (time.time()-rhostart))
-    
+
+    if rank == 0: print(f"rho time: {(time.time()-rhostart):.2f}")
+
     potstart = time.time()
-    
+
     # External field?
     if field:
-    
-        # get SPH expansion for a uniform and constant external field aligned along Z 
+
+        # get SPH expansion for a uniform and constant external field aligned along Z
         omega2 = np.zeros((natoms_total,nrad2),complex)
         for iat in range(natoms_total):
             omega2[iat] = efield.get_efield_sph(nrad2,rcut2)
-    
+
     else:
-    
+
         if rep2=="rho":
-            # get SPH expansion for atomic density    
+            # get SPH expansion for atomic density
             calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
-        
+
         elif rep2=="V":
-            # get SPH expansion for atomic potential 
-            calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL) 
-        
+            # get SPH expansion for atomic potential
+            calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+
         else:
             print("Error: requested representation", rep2, "not provided")
-    
+
         nspe2 = len(neighspe2)
         keys_array = np.zeros(((nang2+1)*len(species)*nspe2,3),int)
         i = 0
@@ -216,41 +230,41 @@ def equirepr(sparsify,field):
                 for speneigh in neighspe2:
                     keys_array[i] = np.array([l,atomic_numbers[specen],atomic_numbers[speneigh]],int)
                     i+=1
-        
+
         keys_selection = Labels(
             names=["spherical_harmonics_l","species_center","species_neighbor"],
             values=keys_array
         )
-        
+
         spx_pot = calculator.compute(frames, selected_keys=keys_selection)
         spx_pot = spx_pot.keys_to_properties("species_neighbor")
         spx_pot = spx_pot.keys_to_samples("species_center")
-       
-    
-        # Get 2nd set of coefficients as a complex numpy array 
+
+
+        # Get 2nd set of coefficients as a complex numpy array
         omega2 = np.zeros((nang2+1,natoms_total,2*nang2+1,nspe2*nrad2),complex)
         for l in range(nang2+1):
             c2r = sph_utils.complex_to_real_transformation([2*l+1])[0]
             omega2[l,:,:2*l+1,:] = np.einsum('cr,ard->acd',np.conj(c2r.T),spx_pot.block(spherical_harmonics_l=l).values)
-    
-    if rank == 0: print("pot time:", (time.time()-potstart))
-    
-    # Generate directories for saving descriptors 
-    dirpath = os.path.join(inp.saltedpath, "equirepr_"+saltedname)
-    
+
+    if rank == 0: print(f"pot time: {(time.time()-potstart):.2f}")
+
+    # Generate directories for saving descriptors
+    dirpath = osp.join(inp.saltedpath, f"equirepr_{saltedname}")
+
     if rank == 0:
         wigner.build(field)
-        if not os.path.exists(dirpath):
+        if not osp.exists(dirpath):
             os.mkdir(dirpath)
     if size > 1: comm.Barrier()
 
     # Compute equivariant descriptors for each lambda value entering the SPH expansion of the electron density
     for lam in range(lmax_max+1):
-    
+
         if rank == 0: print("lambda =", lam)
-    
+
         equistart = time.time()
-    
+
         # External field?
         if field:
             # Select relevant angular components for equivariant descriptor calculation
@@ -273,32 +287,32 @@ def equirepr(sparsify,field):
                         if abs(l2-lam) <= l1 and l1 <= (l2+lam) :
                             lvalues[llmax] = [l1,l2]
                             llmax+=1
-    
+
         # Fill dense array from dictionary
         llvec = np.zeros((llmax,2),int)
-        for il in range(llmax): 
+        for il in range(llmax):
             llvec[il,0] = lvalues[il][0]
             llvec[il,1] = lvalues[il][1]
-        
+
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
         if field:
-            wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_field.dat")
-            wigdim = wigner3j.size 
-        else:
-            wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_lmax2-"+str(nang2)+".dat")
+            wigner3j = np.loadtxt(osp.join(inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_field.dat"))
             wigdim = wigner3j.size
-      
-        # Reshape arrays of expansion coefficients for optimal Fortran indexing 
+        else:
+            wigner3j = np.loadtxt(osp.join(inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"))
+            wigdim = wigner3j.size
+
+        # Reshape arrays of expansion coefficients for optimal Fortran indexing
         v1 = np.transpose(omega1,(2,0,3,1))
         if field:
             v2 = omega2.T
         else:
             v2 = np.transpose(omega2,(2,0,3,1))
-        
-    
+
+
         # Compute complex to real transformation matrix for the given lambda value
         c2r = sph_utils.complex_to_real_transformation([2*lam+1])[0]
-    
+
         if field:
            # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018) by having the field components as second entry
            p = equicombfield.equicombfield(natoms_total,nang1,nspe1*nrad1,nrad2,v1,v2,wigdim,wigner3j,llmax,llvec.T,lam,c2r)
@@ -307,26 +321,26 @@ def equirepr(sparsify,field):
         else:
            # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018)
            p = equicomb.equicomb(natoms_total,nang1,nang2,nspe1*nrad1,nspe2*nrad2,v1,v2,wigdim,wigner3j,llmax,llvec.T,lam,c2r)
-           # Define feature space size 
+           # Define feature space size
            featsize = nspe1*nspe2*nrad1*nrad2*llmax
-    
+
         # Reshape equivariant descriptor
         p = np.transpose(p,(4,0,1,2,3)).reshape(natoms_total,2*lam+1,featsize)
-     
-        if rank == 0: print("equivariant time:", (time.time()-equistart))
-        
+
+        if rank == 0: print(f"equivariant time: {(time.time()-equistart):.2f}")
+
         normstart = time.time()
-        
-        # Normalize equivariant descriptor 
+
+        # Normalize equivariant descriptor
         inner = np.einsum('ab,ab->a', p.reshape(natoms_total,(2*lam+1)*featsize),p.reshape(natoms_total,(2*lam+1)*featsize))
-        p = np.einsum('abc,a->abc', p,1.0/np.sqrt(inner))
-    
-        if rank == 0: print("norm time:", (time.time()-normstart))
-    
+        p = np.einsum('abc,a->abc', p, 1.0/np.sqrt(inner))
+
+        if rank == 0: print(f"norm time: {(time.time()-normstart):.2f}")
+
         savestart = time.time()
-       
-        if rank == 0: print("feature space size =", featsize)
-    
+
+        if rank == 0: print(f"feature space size = {featsize}")
+
         #TODO modify SALTED to directly deal with compact natoms_total dimension
         if lam==0:
             p = p.reshape(natoms_total,featsize)
@@ -334,57 +348,71 @@ def equirepr(sparsify,field):
         else:
             p = p.reshape(natoms_total,2*lam+1,featsize)
             pvec = np.zeros((ndata,natmax,2*lam+1,featsize))
-    
+
         j = 0
         for i,iconf in enumerate(conf_range):
             for iat in range(natoms[iconf]):
                 pvec[i,iat] = p[j]
                 j += 1
-    
+
         # Do feature selection with FPS sparsification
         if sparsify:
             if ncut >= featsize:
-                ncut = featsize  
+                ncut = featsize
             if rank == 0: print("fps...")
             pvec = pvec.reshape(ndata*natmax*(2*lam+1),featsize)
             vfps = do_fps(pvec.T,ncut,0)
             if field:
-                np.save(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+"_field.npy", vfps)
+                np.save(osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"fps{ncut}-{lam}_field.npy"), vfps)
             else:
-                np.save(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+".npy", vfps)
-    
+                np.save(osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"fps{ncut}-{lam}.npy"), vfps)
+
         else:
             if field==True:
                 if inp.parallel:
-                    h5f = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+"_field.h5",'w',driver='mpio',comm=MPI.COMM_WORLD)
+                    h5f = h5py.File(
+                        osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}_field.h5"),
+                        mode='w', driver='mpio', comm=MPI.COMM_WORLD,
+                    )
                 else:
-                    h5f = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+"_field.h5",'w')
+                    h5f = h5py.File(
+                        osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}_field.h5"),
+                        mode='w',
+                    )
             else:
                 if inp.parallel:
-                    h5f = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+".h5",'w',driver='mpio',comm=MPI.COMM_WORLD)
+                    h5f = h5py.File(
+                        osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}.h5"),
+                        mode='w', driver='mpio', comm=MPI.COMM_WORLD,
+                    )
                 else:
-                    h5f = h5py.File(inp.saltedpath+"equirepr_"+saltedname+"/FEAT-"+str(lam)+".h5",'w')
-    
+                    h5f = h5py.File(
+                        osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"FEAT-{lam}.h5"),
+                        mode='w',
+                    )
+
             if ncut < 0 or ncut >= featsize:
                 ncut_l = featsize
             else:
                 ncut_l = ncut
             if lam==0:
-                dset = h5f.create_dataset("descriptor",(ndata_true,natmax,ncut_l),dtype='float64')
+                dset = h5f.create_dataset("descriptor", (ndata_true,natmax,ncut_l), dtype='float64')
             else:
-                dset = h5f.create_dataset("descriptor",(ndata_true,natmax,(2*lam+1),ncut_l),dtype='float64')
-    
-            # Apply sparsification with precomputed FPS selection 
+                dset = h5f.create_dataset("descriptor", (ndata_true,natmax,(2*lam+1),ncut_l), dtype='float64')
+
+            # Apply sparsification with precomputed FPS selection
             if ncut_l < featsize:
                 # Load sparsification details
                 try:
                     if field:
-                        vfps = np.load(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+"_field.npy")
+                        vfps = np.load(osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"fps{ncut}-{lam}_field.npy"))
                     else:
-                        vfps = np.load(inp.saltedpath+"equirepr_"+saltedname+"/fps"+str(ncut)+"-"+str(lam)+".npy")
+                        vfps = np.load(osp.join(inp.saltedpath, f"equirepr_{saltedname}", f"fps{ncut}-{lam}.npy"))
                 except:
-                    if rank == 0: print("Sparsification must be performed prior to calculating the descritors if ncut > -1. First run this script with the flag -s, then rerun with no flag.")
-                    exit()
+                    if rank == 0:
+                        raise ValueError("Sparsification must be performed prior to calculating the descritors if ncut > -1. First run this script with the flag -s, then rerun with no flag.")
+                    else:
+                        exit()
                 if rank == 0: print("sparsifying...")
                 pvec = pvec.reshape(ndata*natmax*(2*lam+1),featsize)
                 psparse = pvec.T[vfps].T
@@ -394,18 +422,17 @@ def equirepr(sparsify,field):
                     psparse = psparse.reshape(ndata,natmax,(2*lam+1),psparse.shape[-1])
                 # Save sparse feature vector
                 dset[conf_range] = psparse
-    
-            # Save non-sparse descriptor  
+
+            # Save non-sparse descriptor
             else:
                 dset[conf_range] = pvec
-    
+
             h5f.close()
-    
-        if rank == 0: print("save time:", (time.time()-savestart))
-    
-    if rank == 0: print("time:", (time.time()-start))
-    
-    return
+
+        if rank == 0: print(f"save time: {(time.time()-savestart):.2f}")
+
+    if rank == 0: print(f"time: {(time.time()-start):.2f}")
+
 
 if __name__ == "__main__":
     build()

--- a/salted/feature_vector.py
+++ b/salted/feature_vector.py
@@ -1,6 +1,12 @@
+"""
+TODO: replace class arraylist by numpy.concatenate
+"""
+
 import os
 import sys
 import time
+import os.path as osp
+
 import numpy as np
 from scipy import sparse
 
@@ -10,7 +16,7 @@ def build():
 
     sys.path.insert(0, './')
     import inp
-    
+
     if inp.parallel:
         from mpi4py import MPI
         # MPI information
@@ -21,68 +27,70 @@ def build():
     else:
         rank=0
         size=1
-    
+
     species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
-    
+
     #   define a numpy equivalent to an appendable list
     class arraylist:
         def __init__(self):
             self.data = np.zeros((100000,))
             self.capacity = 100000
             self.size = 0
-    
+
         def update(self, row):
             n = row.shape[0]
             self.add(row,n)
-    
+
         def add(self, x, n):
             if self.size+n >= self.capacity:
                 self.capacity *= 2
                 newdata = np.zeros((self.capacity,))
                 newdata[:self.size] = self.data[:self.size]
                 self.data = newdata
-    
+
             self.data[self.size:self.size+n] = x
             self.size += n
-    
+
         def finalize(self):
             return self.data[:self.size]
-    
+
     # sparse-GPR parameters
     M = inp.Menv
     zeta = inp.z
-    
+
     if inp.field:
-        kdir = "kernels_"+inp.saltedname+"_field"
-        fdir = "rkhs-vectors_"+inp.saltedname+"_field"
+        kdir = f"kernels_{inp.saltedname}_field"
+        fdir = f"rkhs-vectors_{inp.saltedname}_field"
     else:
-        kdir = "kernels_"+inp.saltedname
-        fdir = "rkhs-vectors_"+inp.saltedname
-    
-    
+        kdir = f"kernels_{inp.saltedname}"
+        fdir = f"rkhs-vectors_{inp.saltedname}"
+
+
     atom_per_spe, natoms_per_spe = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
-    # compute the weight-vector size 
+
+    # compute the weight-vector size
     cuml_Mcut = {}
     totsize = 0
     for spe in species:
         for l in range(lmax[spe]+1):
             for n in range(nmax[(spe,l)]):
-                Mcut = np.load(inp.saltedpath+kdir+"/spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(0)+".npy").shape[1]
+                Mcut = np.load(os.path.join(
+                    inp.saltedpath, kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}", f"psi-nm_conf{0}.npy"
+                )).shape[1]
                 cuml_Mcut[(spe,l,n)] = totsize
                 totsize += Mcut
-    
-    if rank == 0: print("problem dimensionality:", totsize)
-    
-    dirpath = os.path.join(inp.saltedpath,fdir)
+
+    if rank == 0: print(f"problem dimensionality: {totsize}", flush=True)
+
     if (rank == 0):
+        dirpath = os.path.join(inp.saltedpath, fdir)
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath+fdir, "M"+str(M)+"_zeta"+str(zeta))
+        dirpath = os.path.join(inp.saltedpath, fdir, f"M{M}_zeta{zeta}")
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
-    if size > 1: comm.Barrier()
-    
+    if size > 1:  comm.Barrier()
+
     # Distribute structures to tasks
     if inp.parallel:
         conf_range = get_conf_range(rank,size,ndata,list(range(ndata)))
@@ -90,35 +98,37 @@ def build():
         print('Task',rank+1,'handles the following structures:',conf_range,flush=True)
     else:
         conf_range = range(ndata)
-    
+
     for iconf in conf_range:
-    
-        start = time.time()
-        print(iconf,flush=True)
-    
+
+        start_time = time.time()
+        print(f"{iconf} start", flush=True)
+
         # load reference QM data
-        coefs = np.load(inp.saltedpath+"coefficients/coefficients_conf"+str(iconf)+".npy")
+        coefs = np.load(osp.join(inp.saltedpath, "coefficients", f"coefficients_conf{iconf}.npy"))
         Tsize = len(coefs)
-    
-        # initialize RKHS feature vectors for each channel 
+
+        # initialize RKHS feature vectors for each channel
         Psi = {}
-    
+
         ispe = {}
         for spe in species:
             ispe[spe] = 0
             for l in range(lmax[spe]+1):
-                psi_nm = np.load(inp.saltedpath+kdir+"/spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy") 
+                psi_nm = np.load(osp.join(
+                    inp.saltedpath, kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npy"
+                ))
                 Psi[(spe,l)] = psi_nm
-    
+
     # This would be needed if psi_nm depended on n
     #            Mcut = psi_nm.shape[1]
     #            for n in range(nmax[(spe,l)]):
     #                Psi[(spe,l,n)][:,isize:isize+Mcut] = psi_nm
     #                isize += Mcut
-    
-    
+
+
         # build sparse feature-vector memory efficiently
-    
+
         nrows = Tsize
         ncols = totsize
         srows = arraylist()
@@ -143,23 +153,28 @@ def build():
                     scols.update(nz[1]+cuml_Mcut[(spe,l,n)])
                     i += 2*l+1
             ispe[spe] += 1
-    
+
         psi_nonzero = psi_nonzero.finalize()
         srows = srows.finalize()
         scols = scols.finalize()
         ij = np.vstack((srows,scols))
-    
+
         del srows
         del scols
-    
+
         sparse_psi = sparse.coo_matrix((psi_nonzero, ij), shape=(nrows, ncols))
-        sparse.save_npz(inp.saltedpath+fdir+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npz", sparse_psi)
-    
+        sparse.save_npz(osp.join(
+            inp.saltedpath, fdir, f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npz"
+        ), sparse_psi)
+
         del sparse_psi
         del psi_nonzero
         del ij
 
-    return
+        end_time = time.time()
+        print(f"{iconf} end, time cost = {(end_time - start_time):.2f} s", flush=True)
+
+
 
 if __name__ == "__main__":
     build()

--- a/salted/feature_vector.py
+++ b/salted/feature_vector.py
@@ -83,12 +83,9 @@ def build():
     if rank == 0: print(f"problem dimensionality: {totsize}", flush=True)
 
     if (rank == 0):
-        dirpath = os.path.join(inp.saltedpath, fdir)
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
         dirpath = os.path.join(inp.saltedpath, fdir, f"M{M}_zeta{zeta}")
         if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
+            os.makedirs(dirpath)
     if size > 1:  comm.Barrier()
 
     # Distribute structures to tasks

--- a/salted/get_averages.py
+++ b/salted/get_averages.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import numpy as np
 
@@ -19,7 +20,7 @@ def build():
     print("computing averages...")
     for iconf in range(ndata):
         atoms = atomic_symbols[iconf]
-        coefs = np.load(inp.saltedpath+"coefficients/coefficients_conf"+str(iconf)+".npy")
+        coefs = np.load(os.path.join(inp.saltedpath, "coefficients", f"coefficients_conf{iconf}.npy"))
         i = 0
         for iat in range(natoms[iconf]):
             spe = atoms[iat] 
@@ -33,7 +34,7 @@ def build():
     
     for spe in spelist:
         avcoefs[spe] /= nat_per_species[spe]
-        np.save("averages_"+str(spe)+".npy",avcoefs[spe])
+        np.save(f"averages_{spe}.npy", avcoefs[spe])
 
     return
 

--- a/salted/matrices.py
+++ b/salted/matrices.py
@@ -35,12 +35,9 @@ def build():
     zeta = inp.z
     
     if rank == 0:    
-        dirpath = os.path.join(inp.saltedpath, rdir)
+        dirpath = os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}")
         if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath+rdir+"/", "M"+str(M)+"_zeta"+str(zeta))
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
+            os.makedirs(dirpath)
     if size > 1: comm.Barrier()
 
     # define training set at random or sequentially

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -1,9 +1,16 @@
+"""
+TODO:
+- stop minimization with explicit message from rank 0
+"""
+
 import os
-import numpy as np
-import time
 import random
-from scipy import sparse
 import sys
+import time
+import os.path as osp
+
+import numpy as np
+from scipy import sparse
 from salted.sys_utils import read_system, get_atom_idx, get_conf_range
 
 def build():
@@ -18,16 +25,16 @@ def build():
         comm = MPI.COMM_WORLD
         size = comm.Get_size()
         rank = comm.Get_rank()
-        print('This is task',rank+1,'of',size,flush=True)
+        print(f"This is task {rank+1} of {size}", flush=True)
     else:
         rank=0
 
     if inp.field:
-        fdir = "rkhs-vectors_"+inp.saltedname+"_field"
-        rdir = "regrdir_"+inp.saltedname+"_field"
+        fdir = f"rkhs-vectors_{inp.saltedname}_field"
+        rdir = f"regrdir_{inp.saltedname}_field"
     else:
-        fdir = "rkhs-vectors_"+inp.saltedname
-        rdir = "regrdir_"+inp.saltedname
+        fdir = f"rkhs-vectors_{inp.saltedname}"
+        rdir = f"regrdir_{inp.saltedname}"
 
     species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
 
@@ -42,37 +49,47 @@ def build():
     if inp.average:
         av_coefs = {}
         for spe in species:
-            av_coefs[spe] = np.load("averages_"+str(spe)+".npy")
+            av_coefs[spe] = np.load(f"averages_{spe}.npy")
 
     if rank==0:
         dirpath = os.path.join(inp.saltedpath, rdir)
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath+rdir+"/", "M"+str(M)+"_zeta"+str(zeta))
+        dirpath = os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}")
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
     if size > 1: comm.Barrier()
 
     # define training set at random
     if (inp.Ntrain > ndata):
-        print("More training structures have been requested than are present in the input data.")
-        exit()
+        if rank == 0:
+            raise ValueError(f"More training structures {inp.Ntrain=} have been requested than are present in the input data {ndata=}.")
+        else:
+            exit()
     dataset = list(range(ndata))
     random.Random(3).shuffle(dataset)
     trainrangetot = dataset[:inp.Ntrain]
-    if rank == 0: np.savetxt(inp.saltedpath+rdir+"/training_set_N"+str(inp.Ntrain)+".txt",trainrangetot,fmt='%i')
+    if rank == 0:
+        np.savetxt(osp.join(
+            inp.saltedpath, rdir, f"training_set_N{inp.Ntrain}.txt"
+        ), trainrangetot, fmt='%i')
     #trainrangetot = np.loadtxt("training_set.txt",int)
 
     # Distribute structures to tasks
     ntraintot = int(inp.trainfrac*inp.Ntrain)
 
     if paral:
-        if rank == 0 and ntraintot < size:
-            print('You have requested more processes than training structures. Please reduce the number of processes',flush=True)
-            comm.Abort()
+        if ntraintot < size:
+            if rank == 0:
+                raise ValueError(f"More processes {size=} have been requested than training structures {ntraintot=}. Please reduce the number of processes.")
+            else:
+                exit()
+        # if rank == 0 and ntraintot < size:
+        #     print('You have requested more processes than training structures. Please reduce the number of processes',flush=True)
+        #     comm.Abort()
         trainrange = get_conf_range(rank,size,ntraintot,trainrangetot)
         trainrange = comm.scatter(trainrange,root=0)
-        print('Task',rank+1,'handles the following structures:',trainrange,flush=True)
+        print(f"Task {rank+1} handles the following structures: {trainrange}", flush=True)
     else:
         trainrange = trainrangetot[:ntraintot]
     ntrain = int(len(trainrange))
@@ -80,8 +97,8 @@ def build():
 
     def loss_func(weights,ovlp_list,psi_list):
         """Given the weight-vector of the RKHS, compute the gradient of the electron-density loss function."""
-      
-#        global totsize 
+
+#        global totsize
         totsize = psi_list[0].shape[1]
 
         # init gradient
@@ -90,11 +107,15 @@ def build():
         loss = 0.0
         # loop over training structures
         for iconf in range(ntrain):
-       
+
             # load reference QM data
-            ref_projs = np.load(inp.saltedpath+"projections/projections_conf"+str(trainrange[iconf])+".npy")
-            ref_coefs = np.load(inp.saltedpath+"coefficients/coefficients_conf"+str(trainrange[iconf])+".npy")
-           
+            ref_projs = np.load(osp.join(
+                inp.saltedpath, "projections", f"projections_conf{trainrange[iconf]}.npy"
+            ))
+            ref_coefs = np.load(osp.join(
+                inp.saltedpath, "coefficients", f"coefficients_conf{trainrange[iconf]}.npy"
+            ))
+
             if inp.average:
                 Av_coeffs = np.zeros(ref_coefs.shape[0])
             i = 0
@@ -123,13 +144,15 @@ def build():
         # add regularization term
         loss += reg * np.dot(weights,weights)
 
-        return loss 
+        return loss
 
 
-    def grad_func(weights,ovlp_list,psi_list):
-        """Given the weight-vector of the RKHS, compute the gradient of the electron-density loss function."""
-      
-#        global totsize 
+    def grad_func(weights, ovlp_list, psi_list):
+        """
+        Given the weight-vector of the RKHS, compute the gradient of the electron-density loss function.
+        """
+
+#        global totsize
         totsize = psi_list[0].shape[1]
 
         # init gradient
@@ -137,11 +160,15 @@ def build():
 
         # loop over training structures
         for iconf in range(ntrain):
-       
+
             # load reference QM data
-            ref_projs = np.load(inp.saltedpath+"projections/projections_conf"+str(trainrange[iconf])+".npy")
-            ref_coefs = np.load(inp.saltedpath+"coefficients/coefficients_conf"+str(trainrange[iconf])+".npy")
-          
+            ref_projs = np.load(osp.join(
+                inp.saltedpath, "projections", f"projections_conf{trainrange[iconf]}.npy"
+            ))
+            ref_coefs = np.load(osp.join(
+                inp.saltedpath, "coefficients", f"coefficients_conf{trainrange[iconf]}.npy"
+            ))
+
             if inp.average:
                 Av_coeffs = np.zeros(ref_coefs.shape[0])
             i = 0
@@ -179,19 +206,19 @@ def build():
             print(iconf+1,flush=True)
             #psi_vector = psi_list[iconf].toarray()
             #ovlp_times_psi = np.dot(ovlp_list[iconf],psi_vector)
-            #diag_hessian += 2.0*np.sum(np.multiply(ovlp_times_psi,psi_vector),axis=0)  
+            #diag_hessian += 2.0*np.sum(np.multiply(ovlp_times_psi,psi_vector),axis=0)
 
             ovlp_times_psi = sparse.csc_matrix.dot(psi_list[iconf].T,ovlp_list[iconf])
             temp = np.sum(sparse.csc_matrix.multiply(psi_list[iconf].T,ovlp_times_psi),axis=1)
             diag_hessian += 2.0*np.squeeze(np.asarray(temp))
 
-        #del psi_vector  
+        #del psi_vector
 
-        return diag_hessian 
+        return diag_hessian
 
     def curv_func(cg_dire,ovlp_list,psi_list):
         """Compute curvature on the given CG-direction."""
-      
+
 #        global totsize
         totsize = psi_list[0].shape[1]
 
@@ -203,30 +230,42 @@ def build():
 
         return Ap
 
-    if rank == 0: print("loading matrices...")
-    ovlp_list = [] 
-    psi_list = [] 
+    if rank == 0:  print("loading matrices...")
+    ovlp_list = []
+    psi_list = []
     for iconf in trainrange:
-        ovlp_list.append(np.load(inp.saltedpath+"overlaps/overlap_conf"+str(iconf)+".npy"))
+        ovlp_list.append(np.load(osp.join(
+            inp.saltedpath, "overlaps", f"overlap_conf{iconf}.npy"
+        )))
         # load feature vector as a scipy sparse object
-        psi_list.append(sparse.load_npz(inp.saltedpath+fdir+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npz"))
+        psi_list.append(sparse.load_npz(osp.join(
+            inp.saltedpath, fdir, f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npz"
+        )))
 
     totsize = psi_list[0].shape[1]
-    norm = 1.0/float(ntraintot)
+    norm = 1.0 / float(ntraintot)
 
-    if rank == 0: print("problem dimensionality:", totsize)
+    if rank == 0:  print(f"problem dimensionality: {totsize}")
 
     start = time.time()
 
-    tol = inp.gradtol 
+    tol = inp.gradtol
 
     # preconditioner
     P = np.ones(totsize)
 
+    reg_log10_intstr = str(int(np.log10(reg)))
+
     if inp.restart == True:
-        w = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy")
-        d = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/dvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy")
-        r = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/rvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy")
+        w = np.load(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ))
+        d = np.load(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"dvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ))
+        r = np.load(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"rvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ))
         s = np.multiply(P,r)
         delnew = np.dot(r,s)
     else:
@@ -244,7 +283,7 @@ def build():
     for i in range(100000):
         Ad = curv_func(d,ovlp_list,psi_list)
         if paral:
-            Ad = comm.allreduce(Ad)*norm + 2.0 * reg * d 
+            Ad = comm.allreduce(Ad)*norm + 2.0 * reg * d
         else:
             Ad *= norm
             Ad += 2.0*reg*d
@@ -252,12 +291,20 @@ def build():
         alpha = delnew/curv
         w = w + alpha*d
         if (i+1)%50==0 and rank==0:
-            np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",w)
-            np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/dvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",d)
-            np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/rvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",r)
-        r -= alpha * Ad 
-        if rank == 0: print(i+1, "gradient norm:", np.sqrt(np.sum((r**2))),flush=True)
-        if np.sqrt(np.sum((r**2))) < tol:
+            np.save(osp.join(
+                inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntraintot}_reg{reg_log10_intstr}.npy"
+            ), w)
+            np.save(osp.join(
+                inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"dvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+            ), d)
+            np.save(osp.join(
+                inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"rvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+            ), r)
+        r -= alpha * Ad
+        if rank == 0:
+            # np.sqrt(np.sum((r**2))) == np.linalg.norm(r)
+            print(f"step {i+1}, gradient norm: {np.linalg.norm(r):.3e}", flush=True)
+        if np.linalg.norm(r) < tol:
             break
         else:
             s = np.multiply(P,r)
@@ -267,11 +314,17 @@ def build():
             d = s + beta*d
 
     if rank == 0:
-        np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",w)
-        np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/dvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",d)
-        np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/rvector_N"+str(ntraintot)+"_reg"+str(int(np.log10(reg)))+".npy",r)
+        np.save(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ), w)
+        np.save(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"dvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ), d)
+        np.save(osp.join(
+            inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"rvector_N{ntraintot}_reg{reg_log10_intstr}.npy"
+        ), r)
         print("minimization compleated succesfully!")
-        print("minimization time:", (time.time()-start)/60, "minutes")
+        print(f"minimization time: {((time.time()-start)/60):.2f} minutes")
 
 if __name__ == "__main__":
     build()

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -51,13 +51,10 @@ def build():
         for spe in species:
             av_coefs[spe] = np.load(f"averages_{spe}.npy")
 
+    dirpath = os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}")
     if rank==0:
-        dirpath = os.path.join(inp.saltedpath, rdir)
         if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}")
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
+            os.makedirs(dirpath)
     if size > 1: comm.Barrier()
 
     # define training set at random

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -28,6 +28,7 @@ def build():
         print(f"This is task {rank+1} of {size}", flush=True)
     else:
         rank=0
+        size=1
 
     if inp.field:
         fdir = f"rkhs-vectors_{inp.saltedname}_field"

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -254,7 +254,7 @@ def build():
     # preconditioner
     P = np.ones(totsize)
 
-    reg_log10_intstr = str(int(np.log10(reg)))
+    reg_log10_intstr = str(int(np.log10(reg)))  # for consistency
 
     if inp.restart == True:
         w = np.load(osp.join(

--- a/salted/pyscf/dm2df-pyscf.py
+++ b/salted/pyscf/dm2df-pyscf.py
@@ -1,17 +1,20 @@
+import argparse
 import os
+import sys
+import os.path as osp
+
 import numpy as np
 from pyscf import gto
 from ase.io import read
 from scipy import special
-import argparse
-import basis
 
-import sys
+import basis  # WARNING: relative import
+
 sys.path.insert(0, './')
 import inp
 
-def add_command_line_arguments(parsetext):
-    parser = argparse.ArgumentParser(description=parsetext,formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+def add_command_line_arguments():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("-iconf", "--confidx",  type=int, default=-1, help="Structure index")
     args = parser.parse_args()
     return args
@@ -87,7 +90,9 @@ for iconf in conf_list:
     eri3c = pmol.intor('int3c2e_sph', shls_slice=(0,mol.nbas,0,mol.nbas,mol.nbas,mol.nbas+auxmol.nbas))
     eri3c = eri3c.reshape(mol.nao_nr(), mol.nao_nr(), -1)
     # Load 1-electron reduced density-matrix
-    dm=np.load(inp.path2qm+"density_matrices/dm_conf"+str(iconf+1)+".npy")
+    dm=np.load(osp.join(
+        inp.path2qm, "density_matrices", f"dm_conf{iconf+1}.npy"
+    ))
     # Compute density fitted coefficients
     rho = np.einsum('ijp,ij->p', eri3c, dm)
     rho = np.linalg.solve(eri2c, rho)
@@ -140,9 +145,9 @@ for iconf in conf_list:
     Proj = np.dot(Over,Coef)
     
     # Save projections and overlaps
-    np.save(inp.path2qm+inp.coefdir+"coefficients_conf"+str(iconf)+".npy",Coef)
-    np.save(inp.path2qm+inp.projdir+"projections_conf"+str(iconf)+".npy",Proj)
-    np.save(inp.path2qm+inp.ovlpdir+"overlap_conf"+str(iconf)+".npy",Over)
+    np.save(f"inp.path2qm", "inp.coefdir", "coefficients_conf{iconf}.npy", Coef)
+    np.save(f"inp.path2qm", "inp.projdir", "projections_conf{iconf}.npy", Proj)
+    np.save(f"inp.path2qm", "inp.ovlpdir", "overlap_conf{iconf}.npy", Over)
     
     # --------------------------------------------------
     

--- a/salted/pyscf/electro_energy-pyscf.py
+++ b/salted/pyscf/electro_energy-pyscf.py
@@ -1,10 +1,12 @@
+import sys
 import time
+
 import numpy as np
 from pyscf import gto
 from ase.io import read
 from scipy import special
-import basis
-import sys
+
+import basis  # WARNING: relative import
 sys.path.insert(0, './')
 import inp
 
@@ -102,7 +104,9 @@ for iconf in range(ndata):
     nele = np.sum(valences)
     natoms = len(atoms)
     # Load projections and overlaps
-    rcoeffs = np.load(inp.path2qm+inp.coefdir+"coefficients_conf"+str(iconf)+".npy")
+    rcoeffs = np.load(os.path.join(
+        inp.path2qm, inp.coefdir, f"coefficients_conf{iconf}.npy"
+    ))
     ref_coeffs = np.zeros((natoms,llmax+1,nnmax,2*llmax+1))
     ref_rho = np.zeros(len(rcoeffs))
     icoeff = 0

--- a/salted/pyscf/electro_error-pyscf.py
+++ b/salted/pyscf/electro_error-pyscf.py
@@ -1,9 +1,12 @@
+import os
+import sys
+
 import numpy as np
 from pyscf import gto
 from ase.io import read
 from scipy import special
-import basis
-import sys
+
+import basis  # WARNING: relative import
 sys.path.insert(0, './')
 import inp
 
@@ -115,7 +118,9 @@ for iconf in testrange:
     natoms = len(atoms)
     # Load projections and overlaps
 #    projs = np.load(inp.path2qm+"projections/projections_conf"+str(iconf)+".npy")
-    rcoeffs = np.load(inp.path2ml+pdir+"M"+str(M)+"_eigcut"+str(int(np.log10(eigcut)))+"/N_"+str(ntrain)+"/prediction_conf"+str(iconf)+".npy")
+    rcoeffs = np.load(os.path.join(
+        inp.path2ml, pdir, f"M{M}_eigcut{int(np.log10(eigcut))}", f"N_{ntrain}", f"prediction_conf{iconf}.npy"
+    ))
     ref_coeffs = np.zeros((natoms,llmax+1,nnmax,llmax*2+1))
     ref_rho = np.zeros(rcoeffs.shape,float)
     icoeff = 0

--- a/salted/pyscf/run-pyscf.py
+++ b/salted/pyscf/run-pyscf.py
@@ -1,12 +1,13 @@
+import argparse
 import os
 import sys
+
 import numpy as np
+from ase.io import read
 from pyscf import gto
 from pyscf import scf,dft
-from ase.io import read
-from scipy import special
-import argparse
 from pyscf import grad
+from scipy import special
 
 sys.path.insert(0, './')
 import inp
@@ -69,4 +70,4 @@ for iconf in conf_list:
     if not os.path.exists(dirpath):
         os.mkdir(dirpath)
     
-    np.save(inp.path2qm+"density_matrices/dm_conf"+str(iconf+1)+".npy",dm)
+    np.save(os.path.join(inp.path2qm, "density_matrices", f"dm_conf{iconf+1}.npy", dm))

--- a/salted/regression.py
+++ b/salted/regression.py
@@ -1,6 +1,10 @@
+import os
 import sys
-import numpy as np
 import time
+import os.path as osp
+
+import numpy as np
+
 
 def build():
 
@@ -13,33 +17,32 @@ def build():
     zeta = inp.z
     
     if inp.field:
-        kdir = "kernels_"+inp.saltedname+"_field"
-        fdir = "rkhs-vectors_"+inp.saltedname+"_field"
-        rdir = "regrdir_"+inp.saltedname+"_field"
+        kdir = f"kernels_{inp.saltedname}_field"
+        fdir = f"rkhs-vectors_{inp.saltedname}_field"
+        rdir = f"regrdir_{inp.saltedname}_field"
     else:
-        kdir = "kernels_"+inp.saltedname
-        fdir = "rkhs-vectors_"+inp.saltedname
-        rdir = "regrdir_"+inp.saltedname
+        kdir = f"kernels_{inp.saltedname}"
+        fdir = f"rkhs-vectors_{inp.saltedname}"
+        rdir = f"regrdir_{inp.saltedname}"
     
     # define training set size 
     ntrain = round(inp.trainfrac*inp.Ntrain)
     
     # load regression matrices
-    Avec = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Avec_N"+str(ntrain)+".npy")
+    Avec = np.load(osp.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Avec_N{ntrain}.npy"))
     totsize = Avec.shape[0]
     print("problem dimensionality:", totsize,flush=True)
-    if totsize>70000:
-        print("ERROR: problem dimension too large, minimize directly loss-function instead!")
-        sys.exit(0)
-    Bmat = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/Bmat_N"+str(ntrain)+".npy")
+    if totsize > 70000:
+        raise ValueError(f"problem dimension too large ({totsize=}), minimize directly loss-function instead!")
+    Bmat = np.load(osp.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"Bmat_N{ntrain}.npy"))
     
     start = time.time()
     
     w = np.linalg.solve(Bmat+np.eye(totsize)*reg,Avec)
     
-    print("regression time:", (time.time()-start)/60, "minutes")
+    print(f"regression time: {((time.time()-start)/60):.3f} minutes")
     
-    np.save(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+".npy",w)
+    np.save(osp.join(inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntrain}_reg{int(np.log10(reg))}.npy"), w)
 
     return
 

--- a/salted/rkhs.py
+++ b/salted/rkhs.py
@@ -9,7 +9,7 @@ def build():
 
     sys.path.insert(0, './')
     import inp
-    
+
     if inp.parallel:
         from mpi4py import MPI
         # MPI information
@@ -19,19 +19,20 @@ def build():
     #    print('This is task',rank+1,'of',size)
     else:
         rank = 0
-    
+        size = 0
+
     saltedname = inp.saltedname
-    
+
     if inp.field==True:
         kdir = inp.saltedpath+"kernels_"+saltedname+"_field"
     else:
         kdir = inp.saltedpath+"kernels_"+saltedname
     kdir += '/'
-    
+
     species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
-    
+
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
+
     # number of sparse environments
     M = inp.Menv
     zeta = inp.z
@@ -41,7 +42,7 @@ def build():
         print("zeta =", zeta)
         print("Computing RKHS of symmetry-adapted sparse kernel approximations...")
     sdir = inp.saltedpath+'equirepr_'+inp.saltedname+'/'
-    
+
     # Distribute structures to tasks
     if inp.parallel:
         conf_range = get_conf_range(rank,size,ndata,list(range(ndata)))
@@ -49,29 +50,29 @@ def build():
         print('Task',rank+1,'handles the following structures:',conf_range,flush=True)
     else:
         conf_range = list(range(ndata))
-    
+
     power_env_sparse = {}
     if inp.field: power_env_sparse2 = {}
     kernel0_nm = {}
-    
+
     power = h5py.File(sdir+"FEAT-0.h5",'r')["descriptor"][conf_range,:]
     nfeat = power.shape[-1]
     if inp.field:
         power2 = h5py.File(sdir+"FEAT-0_field.h5",'r')["descriptor"][conf_range,:]
         nfeat2 = power2.shape[-1]
     Mspe = {}
-    
+
     for spe in species:
         if rank == 0: print("lambda = 0", "species:", spe)
         start = time.time()
-    
-        # compute sparse kernel K_MM for each atomic species 
+
+        # compute sparse kernel K_MM for each atomic species
         power_env_sparse[spe] = h5py.File(sdir+"FEAT-0-M-"+str(M)+".h5",'r')[spe][:]
         if inp.field: power_env_sparse2[spe] = h5py.File(sdir+"FEAT-0-M-"+str(M)+"_field.h5",'r')[spe][:]
         Mspe[spe] = power_env_sparse[spe].shape[0]
-    
+
         V = np.load(kdir+"spe"+str(spe)+"_l"+str(0)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
-        
+
         # compute feature vector Phi associated with the RKHS of K_NM * K_MM^-1 * K_NM^T
         for i,iconf in enumerate(conf_range):
             kernel0_nm[(iconf,spe)] = np.dot(power[i,atom_idx[(iconf,spe)]],power_env_sparse[spe].T)
@@ -84,10 +85,10 @@ def build():
             psi_nm = np.real(np.dot(kernel_nm,V))
             np.save(kdir+"spe"+str(spe)+"_l"+str(0)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy",psi_nm)
         if rank == 0: print((time.time()-start)/60.0)
-    
+
     # lambda>0
     for l in range(1,llmax+1):
-    
+
         # load power spectrum
         if rank == 0: print("loading lambda =", l)
         power = h5py.File(sdir+"FEAT-"+str(l)+".h5",'r')["descriptor"][conf_range,:]
@@ -95,32 +96,32 @@ def build():
         if inp.field:
             power2 = h5py.File(sdir+"FEAT-"+str(l)+"_field.h5",'r')["descriptor"][conf_range,:]
             nfeat2 = power2.shape[-1]
-    
+
         for spe in species:
             if rank == 0: print("lambda = ", l, "species:", spe)
             start = time.time()
-    
+
             # get sparse feature vector for each atomic species
             power_env_sparse[spe] = h5py.File(sdir+"FEAT-"+str(l)+"-M-"+str(M)+".h5",'r')[spe][:]
             if inp.field: power_env_sparse2[spe] = h5py.File(sdir+"FEAT-"+str(l)+"-M-"+str(M)+"_field.h5",'r')[spe][:]
-            V = np.load(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy") 
-    
+            V = np.load(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
+
             # compute feature vector Phi associated with the RKHS of K_NM * K_MM^-1 * K_NM^T
             if zeta==1:
                 for i,iconf in enumerate(conf_range):
-                    if inp.field: 
-                        kernel_nm = np.dot(power2[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat2),power_env_sparse2[spe].T) 
+                    if inp.field:
+                        kernel_nm = np.dot(power2[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat2),power_env_sparse2[spe].T)
                     else:
-                        kernel_nm = np.dot(power[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat),power_env_sparse[spe].T) 
+                        kernel_nm = np.dot(power[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat),power_env_sparse[spe].T)
                     psi_nm = np.real(np.dot(kernel_nm,V))
                     np.save(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy",psi_nm)
             else:
                 for i,iconf in enumerate(conf_range):
-                    if inp.field: 
+                    if inp.field:
                         kernel_nm = np.dot(power2[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat2),power_env_sparse2[spe].T)
-                    else: 
+                    else:
                         kernel_nm = np.dot(power[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat),power_env_sparse[spe].T)
-                    
+
                     for i1 in range(natom_dict[(iconf,spe)]):
                         for i2 in range(Mspe[spe]):
                             kernel_nm[i1*(2*l+1):i1*(2*l+1)+2*l+1][:,i2*(2*l+1):i2*(2*l+1)+2*l+1] *= kernel0_nm[(iconf,spe)][i1,i2]**(zeta-1)

--- a/salted/rkhs.py
+++ b/salted/rkhs.py
@@ -22,7 +22,7 @@ def build():
     #    print('This is task',rank+1,'of',size)
     else:
         rank = 0
-        size = 0
+        size = 1
 
     saltedname = inp.saltedname
 

--- a/salted/rkhs.py
+++ b/salted/rkhs.py
@@ -1,6 +1,9 @@
+import os
 import sys
-import numpy as np
 import time
+import os.path as osp
+
+import numpy as np
 import h5py
 
 from salted.sys_utils import read_system, get_atom_idx, get_conf_range
@@ -23,11 +26,10 @@ def build():
 
     saltedname = inp.saltedname
 
-    if inp.field==True:
-        kdir = inp.saltedpath+"kernels_"+saltedname+"_field"
+    if inp.field:
+        kdir = osp.join(inp.saltedpath, f"kernels_{inp.saltedname}_field")
     else:
-        kdir = inp.saltedpath+"kernels_"+saltedname
-    kdir += '/'
+        kdir = osp.join(inp.saltedpath, f"kernels_{inp.saltedname}")
 
     species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
 
@@ -41,13 +43,13 @@ def build():
         print("M =", M, "eigcut =", eigcut)
         print("zeta =", zeta)
         print("Computing RKHS of symmetry-adapted sparse kernel approximations...")
-    sdir = inp.saltedpath+'equirepr_'+inp.saltedname+'/'
+    sdir = osp.join(inp.saltedpath, f"equirepr_{inp.saltedname}")
 
     # Distribute structures to tasks
     if inp.parallel:
         conf_range = get_conf_range(rank,size,ndata,list(range(ndata)))
         conf_range = comm.scatter(conf_range,root=0)
-        print('Task',rank+1,'handles the following structures:',conf_range,flush=True)
+        print(f"Task {rank+1} handles the following structures: {conf_range}", flush=True)
     else:
         conf_range = list(range(ndata))
 
@@ -55,23 +57,23 @@ def build():
     if inp.field: power_env_sparse2 = {}
     kernel0_nm = {}
 
-    power = h5py.File(sdir+"FEAT-0.h5",'r')["descriptor"][conf_range,:]
+    power = h5py.File(osp.join(sdir, "FEAT-0.h5"), 'r')["descriptor"][conf_range, :]
     nfeat = power.shape[-1]
     if inp.field:
-        power2 = h5py.File(sdir+"FEAT-0_field.h5",'r')["descriptor"][conf_range,:]
+        power2 = h5py.File(osp.join(sdir, "FEAT-0_field.h5"), 'r')["descriptor"][conf_range, :]
         nfeat2 = power2.shape[-1]
     Mspe = {}
 
     for spe in species:
-        if rank == 0: print("lambda = 0", "species:", spe)
+        if rank == 0: print(f"lambda = 0 species: {spe}")
         start = time.time()
 
         # compute sparse kernel K_MM for each atomic species
-        power_env_sparse[spe] = h5py.File(sdir+"FEAT-0-M-"+str(M)+".h5",'r')[spe][:]
-        if inp.field: power_env_sparse2[spe] = h5py.File(sdir+"FEAT-0-M-"+str(M)+"_field.h5",'r')[spe][:]
+        power_env_sparse[spe] = h5py.File(osp.join(sdir, f"FEAT-0-M-{M}.h5"), 'r')[spe][:]
+        if inp.field: power_env_sparse2[spe] = h5py.File(osp.join(sdir, f"FEAT-0-M-{M}_field.h5"), 'r')[spe][:]
         Mspe[spe] = power_env_sparse[spe].shape[0]
 
-        V = np.load(kdir+"spe"+str(spe)+"_l"+str(0)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
+        V = np.load(osp.join(kdir, f"spe{spe}_l{0}", f"M{M}_zeta{zeta}", "projector.npy"))
 
         # compute feature vector Phi associated with the RKHS of K_NM * K_MM^-1 * K_NM^T
         for i,iconf in enumerate(conf_range):
@@ -83,38 +85,42 @@ def build():
             else:
                 kernel_nm = kernel0_nm[(iconf,spe)]**zeta
             psi_nm = np.real(np.dot(kernel_nm,V))
-            np.save(kdir+"spe"+str(spe)+"_l"+str(0)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy",psi_nm)
+            np.save(osp.join(
+                kdir, f"spe{spe}_l{0}", f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npy"
+            ), psi_nm)
         if rank == 0: print((time.time()-start)/60.0)
 
     # lambda>0
     for l in range(1,llmax+1):
 
         # load power spectrum
-        if rank == 0: print("loading lambda =", l)
-        power = h5py.File(sdir+"FEAT-"+str(l)+".h5",'r')["descriptor"][conf_range,:]
+        if rank == 0:  print(f"loading lambda = {l}")
+        power = h5py.File(osp.join(sdir, f"FEAT-{l}.h5"), 'r')["descriptor"][conf_range, :]
         nfeat = power.shape[-1]
         if inp.field:
-            power2 = h5py.File(sdir+"FEAT-"+str(l)+"_field.h5",'r')["descriptor"][conf_range,:]
+            power2 = h5py.File(osp.join(sdir, f"FEAT-{l}_field.h5"), 'r')["descriptor"][conf_range, :]
             nfeat2 = power2.shape[-1]
 
         for spe in species:
-            if rank == 0: print("lambda = ", l, "species:", spe)
+            if rank == 0: print(f"lambda = {l} species: {spe}")
             start = time.time()
 
             # get sparse feature vector for each atomic species
-            power_env_sparse[spe] = h5py.File(sdir+"FEAT-"+str(l)+"-M-"+str(M)+".h5",'r')[spe][:]
-            if inp.field: power_env_sparse2[spe] = h5py.File(sdir+"FEAT-"+str(l)+"-M-"+str(M)+"_field.h5",'r')[spe][:]
-            V = np.load(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/projector.npy")
+            power_env_sparse[spe] = h5py.File(osp.join(sdir, f"FEAT-{l}-M-{M}.h5"), 'r')[spe][:]
+            if inp.field: power_env_sparse2[spe] = h5py.File(osp.join(sdir, f"FEAT-{l}-M-{M}_field.h5"), 'r')[spe][:]
+            V = np.load(osp.join(kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}", "projector.npy"))
 
             # compute feature vector Phi associated with the RKHS of K_NM * K_MM^-1 * K_NM^T
-            if zeta==1:
+            if zeta == 1:
                 for i,iconf in enumerate(conf_range):
                     if inp.field:
                         kernel_nm = np.dot(power2[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat2),power_env_sparse2[spe].T)
                     else:
                         kernel_nm = np.dot(power[i,atom_idx[(iconf,spe)]].reshape(natom_dict[(iconf,spe)]*(2*l+1),nfeat),power_env_sparse[spe].T)
                     psi_nm = np.real(np.dot(kernel_nm,V))
-                    np.save(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy",psi_nm)
+                    np.save(osp.join(
+                        kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npy"
+                    ), psi_nm)
             else:
                 for i,iconf in enumerate(conf_range):
                     if inp.field:
@@ -127,10 +133,11 @@ def build():
                             kernel_nm[i1*(2*l+1):i1*(2*l+1)+2*l+1][:,i2*(2*l+1):i2*(2*l+1)+2*l+1] *= kernel0_nm[(iconf,spe)][i1,i2]**(zeta-1)
                             #kernel_nm[i1*(2*l+1):i1*(2*l+1)+2*l+1][:,i2*(2*l+1):i2*(2*l+1)+2*l+1] *= np.exp(kernel0_nm[(iconf,spe)][i1,i2])
                     psi_nm = np.real(np.dot(kernel_nm,V))
-                    np.save(kdir+"spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy",psi_nm)
-            if rank == 0: print((time.time()-start)/60.0)
+                    np.save(osp.join(
+                        kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}", f"psi-nm_conf{iconf}.npy"
+                    ), psi_nm)
+            if rank == 0: print(f"time cost: {((time.time()-start)):.2f} s")
 
-    return
 
 if __name__ == "__main__":
     build()

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -1,3 +1,7 @@
+"""
+WARNING: many variables are referenced before defined
+"""
+
 import os
 import sys
 import time
@@ -208,7 +212,9 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Vmat,vfps,charge_integrals
             llvec[il,1] = lvalues[il][1]
         
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
-        wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_lmax2-"+str(nang2)+".dat")
+        wigner3j = np.loadtxt(os.path.join(
+            inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"
+        ))
         wigdim = wigner3j.size
       
         # Reshape arrays of expansion coefficients for optimal Fortran indexing 
@@ -275,7 +281,9 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Vmat,vfps,charge_integrals
                  llvec[il,1] = lvalues[il][1]
     
              # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
-             wigner3j = np.loadtxt(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(nang1)+"_field.dat")
+             wigner3j = np.loadtxt(os.path.join(
+                 inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_field.dat"
+             ))
              wigdim = wigner3j.size
           
              # Perform symmetry-adapted combination following Eq.S19 of Grisafi et al., PRL 120, 036002 (2018)

--- a/salted/sparse-gpr_energies.py
+++ b/salted/sparse-gpr_energies.py
@@ -1,5 +1,7 @@
-import numpy as np
+import os
 import sys
+
+import numpy as np
 from ase.io import read
 
 from salted.sys_utils import read_system
@@ -63,7 +65,7 @@ def build():
     te_energ = energies[testrange]
     
     # load feature vector and define sparse feature vector
-    power_per_conf = np.load(inp.path2ml+inp.soapdir+"FEAT-0.npy")
+    power_per_conf = np.load(os.path.join(inp.path2ml, inp.soapdir, "FEAT-0.npy"))
     nfeat = power_per_conf.shape[-1]
     power_ref_sparse = power_per_conf.reshape(ndata*3,nfeat)[fps_indexes]
     

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -9,10 +9,10 @@ import inp
 
 
 def read_system(filename=inp.filename):
-    
+
     # read species
     spelist = inp.species
-    
+
     # read basis
     [lmax,nmax] = basis.basiset(inp.dfbasis)
     llist = []
@@ -23,14 +23,14 @@ def read_system(filename=inp.filename):
             nlist.append(nmax[(spe,l)])
     nnmax = max(nlist)
     llmax = max(llist)
-    
+
     # read system
     xyzfile = read(filename,":")
     ndata = len(xyzfile)
-   
-    # Define system excluding atoms that belong to species not listed in SALTED input 
+
+    # Define system excluding atoms that belong to species not listed in SALTED input
     atomic_symbols = []
-    natoms = np.zeros(ndata,int) 
+    natoms = np.zeros(ndata,int)
     for iconf in range(len(xyzfile)):
         atomic_symbols.append(xyzfile[iconf].get_chemical_symbols())
         natoms_total = len(atomic_symbols[iconf])
@@ -55,7 +55,7 @@ def get_atom_idx(ndata,natoms,spelist,atomic_symbols):
     natom_dict = {}
     for iconf in range(ndata):
         for spe in spelist:
-            atom_idx[(iconf,spe)] = [] 
+            atom_idx[(iconf,spe)] = []
             natom_dict[(iconf,spe)] = 0
         for iat in range(natoms[iconf]):
             spe = atomic_symbols[iconf][iat]

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -89,3 +89,20 @@ def get_conf_range(rank,size,ntest,testrangetot):
 
     return testrange
 
+
+def sort_grid_data(data:np.ndarray) -> np.ndarray:
+    """Sort real space grid data
+    The grid data is 2D array with 4 columns (x,y,z,value).
+    Sort the grid data in the order of x, y, z.
+
+    Args:
+        data (np.ndarray): grid data, shape (n,4)
+
+    Returns:
+        np.ndarray: sorted grid data, shape (n,4)
+    """
+    assert data.ndim == 2
+    assert data.shape[1] == 4
+    data = data[np.lexsort((data[:,2], data[:,1], data[:,0]))]  # last key is primary
+    return data
+

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -315,7 +315,7 @@ def build():
             ref_coefs -= Av_coeffs
         var = np.dot(ref_coefs,ref_projs)
         variance += var
-        print(iconf+1, np.sqrt(error/var)*100, file=efile)
+        print(f"{iconf+1:d} {(np.sqrt(error/var)*100):.3e}", file=efile)
         print(f"{iconf+1}: {(np.sqrt(error/var)*100):.3e} % RMSE", flush=True)
         #print(iconf+1, ":", "rho integral =", rho_int, "normalized rho integral =", charge, "ref_dipole =", ref_dipole, "dipole =",dipole, ", error =", np.sqrt(error/var)*100, "% RMSE", flush=True)
 

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -1,7 +1,9 @@
 import os
 import sys
-import numpy as np
 import time
+import os.path as osp
+
+import numpy as np
 from scipy import special
 
 #from sympy.parsing import mathematica
@@ -15,7 +17,7 @@ def build():
 
     sys.path.insert(0, './')
     import inp
-    
+
     if inp.parallel:
         from mpi4py import MPI
         # MPI information
@@ -26,29 +28,29 @@ def build():
     else:
         rank = 0
         size = 1
-    
+
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
+
     bohr2angs = 0.529177210670
-    
+
     if inp.field:
-        vdir = "validations_"+inp.saltedname+"_field"
-        rdir = "regrdir_"+inp.saltedname+"_field"
-        kdir = "kernels_"+inp.saltedname+"_field"
+        vdir = f"validations_{inp.saltedname}_field"
+        rdir = f"regrdir_{inp.saltedname}_field"
+        kdir = f"kernels_{inp.saltedname}_field"
     else:
-        vdir = "validations_"+inp.saltedname
-        rdir = "regrdir_"+inp.saltedname
-        kdir = "kernels_"+inp.saltedname
-    
+        vdir = f"validations_{inp.saltedname}"
+        rdir = f"regrdir_{inp.saltedname}"
+        kdir = f"kernels_{inp.saltedname}"
+
     # read basis
-    
+
     # number of sparse environments
     M = inp.Menv
     eigcut = inp.eigcut
     reg = inp.regul
     zeta = inp.z
-    
+
     for iconf in range(ndata):
         # Define relevant species
         excluded_species = []
@@ -59,7 +61,7 @@ def build():
         excluded_species = set(excluded_species)
         for spe in excluded_species:
             atomic_symbols[iconf] = list(filter(lambda a: a != spe, atomic_symbols[iconf]))
-    
+
     # recompute number of atoms
     natoms_total = 0
     natoms_list = []
@@ -71,35 +73,41 @@ def build():
         natoms_total += natoms[iconf]
         natoms_list.append(natoms[iconf])
     natmax = max(natoms_list)
-    
+
     # define test set
-    trainrangetot = np.loadtxt(inp.saltedpath+rdir+"/training_set_N"+str(inp.Ntrain)+".txt",int)
+    trainrangetot = np.loadtxt(osp.join(
+        inp.saltedpath, rdir, f"training_set_N{inp.Ntrain}.txt"
+    ), int)
     ntrain = round(inp.trainfrac*len(trainrangetot))
     testrange = np.setdiff1d(list(range(ndata)),trainrangetot)
-    
+
     # Distribute structures to tasks
     ntest = len(testrange)
     if inp.parallel:
         testrange = get_conf_range(rank,size,ntest,testrange)
         testrange = comm.scatter(testrange,root=0)
-        print('Task',rank+1,'handles the following structures:',testrange,flush=True)
-    
+        print(f"Task {rank+1} handles the following structures: {testrange}", flush=True)
+
+    reg_log10_intstr = str(int(np.log10(reg)))
+
     # load regression weights
-    weights = np.load(inp.saltedpath+rdir+"/M"+str(M)+"_zeta"+str(zeta)+"/weights_N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+".npy")
-    
+    weights = np.load(osp.join(
+        inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntrain}_reg{reg_log10_intstr}.npy"
+    ))
+
     if rank == 0:
         dirpath = os.path.join(inp.saltedpath, vdir)
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath+vdir+"/", "M"+str(M)+"_zeta"+str(zeta))
+        dirpath = os.path.join(inp.saltedpath, vdir, f"M{M}_zeta{zeta}")
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/","N"+str(ntrain)+"_reg"+str(int(np.log10(reg))))
+        dirpath = os.path.join(inp.saltedpath, vdir, f"M{M}_zeta{zeta}", f"N{ntrain}_reg{reg_log10_intstr}")
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
     if size > 1: comm.Barrier()
-    
-    
+
+
     if inp.qmcode=="cp2k":
         # get basis set info from CP2K BASIS_LRIGPW_AUXMOLOPT
         if rank == 0: print("Reading auxiliary basis info...")
@@ -107,7 +115,7 @@ def build():
         sigmas = {}
         for spe in species:
             for l in range(lmax[spe]+1):
-                avals = np.loadtxt(spe+"-"+inp.dfbasis+"-alphas-L"+str(l)+".dat")
+                avals = np.loadtxt(osp.join(f"{spe}-{inp.dfbasis}-alphas-L{l}.dat"))
                 if nmax[(spe,l)]==1:
                     alphas[(spe,l,0)] = float(avals)
                     sigmas[(spe,l,0)] = np.sqrt(0.5/alphas[(spe,l,0)]) # bohr
@@ -115,7 +123,7 @@ def build():
                     for n in range(nmax[(spe,l)]):
                         alphas[(spe,l,n)] = avals[n]
                         sigmas[(spe,l,n)] = np.sqrt(0.5/alphas[(spe,l,n)]) # bohr
-        
+
         # compute integrals of basis functions (needed to a posteriori correction of the charge)
         charge_integrals = {}
         dipole_integrals = {}
@@ -129,7 +137,7 @@ def build():
                     dipole_radint = 2**float(1.0+float(l)/2.0) * sigmas[(spe,l,n)]**(4+l) * special.gamma(2.0+float(l)/2.0)
                     charge_integrals[(spe,l,n)] = charge_radint * np.sqrt(4.0*np.pi) / np.sqrt(inner)
                     dipole_integrals[(spe,l,n)] = dipole_radint * np.sqrt(4.0*np.pi/3.0) / np.sqrt(inner)
-    
+
     # If total charge density is asked, read in the GTH pseudo-charge and return a radial numpy function
     #if inp.totcharge:
     #    pseudof = open(inp.pseudochargefile,"r")
@@ -146,20 +154,28 @@ def build():
     #        pseudocharge += r**2*pseudochargedensity(r)
     #    pseudocharge *= 4*np.pi*dr
     #    print("Integrated pseudo-charge =", pseudocharge)
-    
+
     # Load spherical averages if required
     if inp.average:
         av_coefs = {}
         for spe in inp.species:
-            av_coefs[spe] = np.load("averages_"+str(spe)+".npy")
-    
+            av_coefs[spe] = np.load(f"averages_{spe}.npy")
+
     # compute error over test set
-    
-    efname = inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/errors.dat"
-    if rank == 0 and os.path.exists(efname): os.remove(efname)
+
+    efname = osp.join(
+        inp.saltedpath, vdir, f"M{M}_zeta{zeta}",
+        f"N{ntrain}_reg{reg_log10_intstr}", f"errors.dat"
+    )
+    if rank == 0 and os.path.exists(efname):
+        os.remove(efname)
     if inp.qmcode == "cp2k":
-        dfname = inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/dipoles.dat"
-        qfname = inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/charges.dat"
+        dfname = osp.join(
+            inp.saltedpath, vdir, f"M{M}_zeta{zeta}", f"N{ntrain}_reg{reg_log10_intstr}", f"dipoles.dat"
+        )
+        qfname = osp.join(
+            inp.saltedpath, vdir, f"M{M}_zeta{zeta}", f"N{ntrain}_reg{reg_log10_intstr}", f"charges.dat"
+        )
         if rank == 0 and os.path.exists(dfname): os.remove(dfname)
         if rank == 0 and os.path.exists(qfname): os.remove(qfname)
     if inp.parallel: comm.Barrier()
@@ -167,17 +183,21 @@ def build():
     if inp.qmcode=="cp2k":
         dfile = open(dfname,"a")
         qfile = open(qfname,"a")
-    
+
     error_density = 0
     variance = 0
     for iconf in testrange:
-    
+
         # load reference
-        ref_coefs = np.load(inp.saltedpath+"coefficients/coefficients_conf"+str(iconf)+".npy")
-        overl = np.load(inp.saltedpath+"overlaps/overlap_conf"+str(iconf)+".npy")
+        ref_coefs = np.load(osp.join(
+            inp.saltedpath, "coefficients", f"coefficients_conf{iconf}.npy"
+        ))
+        overl = np.load(osp.join(
+            inp.saltedpath, "overlaps", f"overlap_conf{iconf}.npy"
+        ))
         ref_projs = np.dot(overl,ref_coefs)
         Tsize = len(ref_coefs)
-    
+
         # compute predictions per channel
         C = {}
         ispe = {}
@@ -187,12 +207,15 @@ def build():
             ispe[spe] = 0
             for l in range(lmax[spe]+1):
                 for n in range(nmax[(spe,l)]):
-                    psi_nm = np.load(inp.saltedpath+kdir+"/spe"+str(spe)+"_l"+str(l)+"/M"+str(M)+"_zeta"+str(zeta)+"/psi-nm_conf"+str(iconf)+".npy") 
+                    psi_nm = np.load(osp.join(
+                        inp.saltedpath, kdir, f"spe{spe}_l{l}", f"M{M}_zeta{zeta}",
+                        f"psi-nm_conf{iconf}.npy"
+                    ))
                     Mcut = psi_nm.shape[1]
                     C[(spe,l,n)] = np.dot(psi_nm,weights[isize:isize+Mcut])
                     isize += Mcut
                     iii += 1
-            
+
         # fill vector of predictions
         pred_coefs = np.zeros(Tsize)
         if inp.average:
@@ -207,21 +230,21 @@ def build():
                         Av_coeffs[i] = av_coefs[spe][n]
                     i += 2*l+1
             ispe[spe] += 1
-    
+
         # add back spherical averages if required
         if inp.average:
             pred_coefs += Av_coeffs
-    
+
         if inp.qmcode=="cp2k":
-            
+
             from ase.io import read
-            xyzfile = read(inp.filename,":")
+            xyzfile = read(inp.filename, ":")
             geom = xyzfile[iconf]
             geom.wrap()
             coords = geom.get_positions()/bohr2angs
             all_symbols = xyzfile[iconf].get_chemical_symbols()
             all_natoms = int(len(all_symbols))
-       
+
             # compute integral of predicted density
             iaux = 0
             nele = 0.0
@@ -236,7 +259,7 @@ def build():
                             rho_int += charge_integrals[(spe,l,n)] * pred_coefs[iaux]
                             ref_rho_int += charge_integrals[(spe,l,n)] * ref_coefs[iaux]
                         iaux += 2*l+1
-      
+
             # compute charge and dipole
             iaux = 0
             charge = 0.0
@@ -269,18 +292,27 @@ def build():
                                 iaux += 1
             print(iconf+1,ref_dipole,dipole,file=dfile)
             print(iconf+1,ref_charge,rho_int,file=qfile)
-    
+
         # save predicted coefficients
-        np.save(inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/prediction_conf"+str(iconf)+".npy",pred_coefs)
-    
+        np.save(osp.join(
+            inp.saltedpath, vdir, f"M{M}_zeta{zeta}",
+            f"N{ntrain}_reg{reg_log10_intstr}", f"prediction_conf{iconf}.npy"
+        ), pred_coefs)
+
         # save reference coefficients
-        np.savetxt(inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/RI-COEFFS-"+str(iconf+1)+".dat",ref_coefs)
+        np.savetxt(osp.join(
+            inp.saltedpath, vdir, f"M{M}_zeta{zeta}",
+            f"N{ntrain}_reg{reg_log10_intstr}", f"RI-COEFFS-{iconf+1}.dat"
+        ), ref_coefs)
         # save predicted coefficients
-        np.savetxt(inp.saltedpath+vdir+"/M"+str(M)+"_zeta"+str(zeta)+"/N"+str(ntrain)+"_reg"+str(int(np.log10(reg)))+"/COEFFS-"+str(iconf+1)+".dat",pred_coefs)
-    
+        np.savetxt(osp.join(
+            inp.saltedpath, vdir, f"M{M}_zeta{zeta}",
+            f"N{ntrain}_reg{reg_log10_intstr}", f"COEFFS-{iconf+1}.dat"
+        ), pred_coefs)
+
         # compute predicted density projections <phi|rho>
         pred_projs = np.dot(overl,pred_coefs)
-    
+
         # compute error
         error = np.dot(pred_coefs-ref_coefs,pred_projs-ref_projs)
         error_density += error
@@ -289,12 +321,12 @@ def build():
             ref_coefs -= Av_coeffs
         var = np.dot(ref_coefs,ref_projs)
         variance += var
-        print(iconf+1,np.sqrt(error/var)*100,file=efile)
-        print(iconf+1, ":", np.sqrt(error/var)*100, "% RMSE", flush=True)
+        print(iconf+1, np.sqrt(error/var)*100, file=efile)
+        print(f"{iconf+1}: {(np.sqrt(error/var)*100):.3e} % RMSE", flush=True)
         #print(iconf+1, ":", "rho integral =", rho_int, "normalized rho integral =", charge, "ref_dipole =", ref_dipole, "dipole =",dipole, ", error =", np.sqrt(error/var)*100, "% RMSE", flush=True)
-    
+
         # UNCOMMENT TO CHECK PREDICTIONS OF <phi|rho-rho_0>
-        # ------------------------------------------------- 
+        # -------------------------------------------------
     #    pred_projs = np.dot(overl,pred_coefs-Av_coeffs)
     #    av_projs = np.dot(overl,Av_coeffs)
     #    iaux = 0
@@ -306,27 +338,26 @@ def build():
     #                    if l==4 and im==0:
     #                        print(pred_projs[iaux],ref_projs[iaux])
     #                    iaux += 1
-    
+
     efile.close()
     if inp.qmcode == "cp2k":
         dfile.close()
         qfile.close()
-    
+
     if inp.parallel:
         error_density = comm.allreduce(error_density)
         variance = comm.allreduce(variance)
         if rank == 0:
             errs = np.loadtxt(efname)
-            np.savetxt(efname,errs[errs[:,0].argsort()])
+            np.savetxt(efname, errs[errs[:,0].argsort()])
             if inp.qmcode == "cp2k":
                 dips = np.loadtxt(dfname)
-                np.savetxt(dfname,dips[dips[:,0].argsort()])
+                np.savetxt(dfname, dips[dips[:,0].argsort()])
                 qs = np.loadtxt(qfname)
-                np.savetxt(qfname,qs[qs[:,0].argsort()])
-    if rank == 0: print("")
-    if rank == 0: print("% RMSE =", 100*np.sqrt(error_density/variance))
+                np.savetxt(qfname, qs[qs[:,0].argsort()])
+    if rank == 0:
+        print(f"\nsummary: {(100*np.sqrt(error_density/variance)):.3e} % RMSE", flush=True)
 
-    return
 
 if __name__ == "__main__":
     build()

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -95,16 +95,10 @@ def build():
         inp.saltedpath, rdir, f"M{M}_zeta{zeta}", f"weights_N{ntrain}_reg{reg_log10_intstr}.npy"
     ))
 
+    dirpath = os.path.join(inp.saltedpath, vdir, f"M{M}_zeta{zeta}", f"N{ntrain}_reg{reg_log10_intstr}")
     if rank == 0:
-        dirpath = os.path.join(inp.saltedpath, vdir)
         if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath, vdir, f"M{M}_zeta{zeta}")
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
-        dirpath = os.path.join(inp.saltedpath, vdir, f"M{M}_zeta{zeta}", f"N{ntrain}_reg{reg_log10_intstr}")
-        if not os.path.exists(dirpath):
-            os.mkdir(dirpath)
+            os.makedirs(dirpath)
     if size > 1: comm.Barrier()
 
 

--- a/salted/wigner.py
+++ b/salted/wigner.py
@@ -1,7 +1,9 @@
 import os
 import sys
-import ase
 import time
+import os.path as osp
+
+import ase
 import numpy as np
 from sympy.physics.wigner import wigner_3j
 
@@ -12,21 +14,21 @@ from salted import basis
 def build(field):
     sys.path.insert(0, './')
     import inp
-    
+
     from salted.sys_utils import read_system, get_atom_idx
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
-    
-    # Generate directories for saving descriptors 
+
+    # Generate directories for saving descriptors
     dirpath = os.path.join(inp.saltedpath, "wigners")
     if not os.path.exists(dirpath):
         os.mkdir(dirpath)
-    
+
     # Compute equivariant descriptors for each lambda value entering the SPH expansion of the electron density
     for lam in range(lmax_max+1):
-    
-        print("lambda =", lam)
-    
+
+        print(f"lambda = {lam}")
+
         # External field?
         if field:
             # Select relevant angular components for equivariant descriptor calculation
@@ -49,16 +51,18 @@ def build(field):
                         if abs(l2-lam) <= l1 and l1 <= (l2+lam) :
                             lvalues[llmax] = [l1,l2]
                             llmax+=1
-    
+
         # Fill dense array from dictionary
         llvec = np.zeros((llmax,2),int)
-        for il in range(llmax): 
+        for il in range(llmax):
             llvec[il,0] = lvalues[il][0]
             llvec[il,1] = lvalues[il][1]
-        
-        # Precompute Wigner-3J symbols and save to file as dense arrays 
+
+        # Precompute Wigner-3J symbols and save to file as dense arrays
         if field:
-            wig = open(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(inp.nang1)+"_field.dat","a")
+            wig = open(osp.join(
+                inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{inp.nang1}_field.dat"
+            ), "a")
             iwig = 0
             for il in range(llmax):
                 l1 = lvalues[il][0]
@@ -74,7 +78,9 @@ def build(field):
                             print(float(w3j),file=wig)
             wig.close()
         else:
-            wig = open(inp.saltedpath+"wigners/wigner_lam-"+str(lam)+"_lmax1-"+str(inp.nang1)+"_lmax2-"+str(inp.nang2)+".dat","a")
+            wig = open(osp.join(
+                inp.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{inp.nang1}_lmax2-{inp.nang2}.dat"
+            ), "a")
             iwig = 0
             for il in range(llmax):
                 l1 = lvalues[il][0]


### PR DESCRIPTION
Dear development team,

This pull request focuses on improving clarity of path strings (as what Andrea @andreagrisafi  agrees with), and some performance optimization (I mentioned these to Mariana). Key updates include:

1. **Path string concatenation**: Utilization of `os.path.join()` and `os.makedirs()` has been applied for a more robust and easy-understanding path string concatenation and subdir creating.
1. **Performance enhancements**: Significant improvements have been made in two critical files:
    - **File**: `salted/aims/get_df_err.py`
        - **Improvement**: Implementation of a more efficient method for spatial grid sorting.
        - **Benchmark Results**:
            - Time reduction from 94.7ms to 21.7ms in a specific code segment attached below.
            - On the first 100 training samples of the ZrS2 dataset (Zr2S4), total execution time decreased from 527s to 408s without impacting the accuracy of results.
    - **File**: `salted/aims/move_data_in.py`
        - **Enhancements**: Optimizations in index reversing and parity reversing segments.
        - **Benchmark Results**:
            - On ZrS2 prediction dataset frame 1 (Zr38S76), the predicted density fitting coefficients array length is 46969
            - Index Reversing: Time reduced dramatically from 113s to 14ms.
            - Parity Reversing: Time decreased from 19ms to 3ms.
            - A comprehensive timing comparison is included for reference (see below).
1. **Code Refinement**: Minor f-string modifications have been introduced for cleaner code and improved terminal output. These changes are not expected to affect computational results.

I didn't change the cp2k- and pyscf-only code. I have verified this PR by running SALTED with FHI-aims on the ZrS2 dataset.

> **24.01.24 update**: (improving the path strings) I have revised all files in the directory `salted`, except for subdirs `cp2k` and `ortho`. These modifications start from commit `b07bb1b`.

I am confident these enhancements will contribute significantly to our project's efficiency and maintainability. I eagerly await your feedback and am available for any further discussion or clarification.
Thank you for your time and consideration.

Best regards,
Zekun

---

- spatial grid sorting
```python
# r_con is from ZrS2 dataset training frame 1

# before
%%timeit
r_con1 = r_con.copy()  # method in code now
r_con1.view('f8,f8,f8,f8').sort(order=['f0','f1','f2'],axis = 0)
>>> 94.7 ms ± 15.6 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

# after
%%timeit
r_con2 = r_con.copy()  # improved method
r_con2 = r_con2[numpy.lexsort((r_con2[:, 2], r_con2[:, 1], r_con2[:, 0]))]
>>> 21.7 ms ± 79 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# reconfirm results
numpy.allclose(r_con1, r_con2, rtol=1e-8)
>>> True
```

- Index reversing and parity reversing
```python
# before, in seconds
time_load_pred=0.0007796287536621094
time_load_idx=0.009583234786987305
time_rev_idx=111.5866174697876  # <-- index reversing
time_load_cs=0.004029512405395508
time_rev_cs=0.018198728561401367  # <-- parity reversing
time_total=111.61933779716492
# after, in seconds
time_load_pred=0.0008151531219482422
time_load_idx=0.010459423065185547
time_rev_idx=112.59937787055969  # <-- index reversing
time_rev_idx_2=0.01427459716796875  # <-- optimized
test new method correct: True  # by numpy.allclose()
time_load_cs=0.0043964385986328125
time_rev_cs=0.018590450286865234  # <-- parity reversing
time_rev_cs_2=0.003393888473510742  # <-- optimized
test new method correct: True  # by numpy.allclose()
time_total=112.6575288772583
```



