### PR TITLE
enable saving descriptor for prediction dataset, replace class arraylist

### DIFF
--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -2,6 +2,7 @@ import os
 import os.path as osp
 import sys
 import time
+from typing import Dict, List
 
 import h5py
 import numpy as np
@@ -18,8 +19,9 @@ from salted.sys_utils import (
     ParseConfig,
     get_atom_idx,
     get_conf_range,
+    get_feats_projs,
+    get_natmax_in_range,
     read_system,
-    get_feats_projs
 )
 
 
@@ -62,8 +64,9 @@ def build():
     ndata_true = ndata
     if parallel:
         conf_range = get_conf_range(rank,size,ndata,list(range(ndata)))
-        conf_range = comm.scatter(conf_range,root=0)
+        conf_range = comm.scatter(conf_range,root=0)  # List[int]
         ndata = len(conf_range)
+        natmax = max(natoms[conf_range])
         print(f"Task {rank+1} handles the following structures: {conf_range}", flush=True)
     else:
         conf_range = list(range(ndata))
@@ -322,6 +325,12 @@ def build():
                 pvec[lam][i,iat] = p[j]
                 j += 1
 
+    """ save descriptor of the prediction dataset """
+    if inp.prediction.save_descriptor:
+        if rank == 0:
+            print(f"Saving descriptor of the prediction dataset to dir {dirpath}")
+        save_pred_descriptor(pvec, conf_range, list(natoms[conf_range]), dirpath)
+
 #    if parallel:
 #        comm.Barrier()
 #        for lam in range(lmax_max+1):
@@ -461,6 +470,41 @@ def build():
 
     if rank == 0: print(f"\ntotal time: {(time.time()-start):.2f} s")
 
+
+def save_pred_descriptor(data:Dict[int, np.ndarray], config_range:List[int], natoms:List[int], dpath:str):
+    """Save the descriptor data of the prediction dataset.
+
+    Args:
+        data (Dict[int, np.ndarray]): the descriptor data to be saved.
+            int -> lambda value,
+            np.ndarray -> descriptor data, shape (ndata, natmax, [2*lambda+1,] featsize)
+                natmax should be cut to the number of atoms in the structure (natoms[i])
+                2*lambda+1 is only for lambda > 0.
+        config_range (List[int]): the indices of the structures in the full dataset.
+        natoms (List[int]): the number of atoms in each structure. Should be the same length as config_range.
+        dpath (str): the directory to save the descriptor data.
+
+    Output:
+        The descriptor data of each structure is saved in a separate npz file in the directory dpath named as
+        "descriptor_{i}.npz", where i starts from 1.
+        Format: npz file with keys as lambda values and values as the descriptor data.
+            Values have shape (natom, [2*lambda+1,] featsize). 2*lambda+1 is only for lambda > 0.
+    """
+    assert len(config_range) == len(natoms), f"The length of config_range and natoms should be the same, " \
+        f"but get {config_range=} and {natoms=}."
+    for lam, data_this_lam in data.items():
+        assert data_this_lam.shape[0] == len(config_range), \
+            f"The first dimension of the descriptor data should be the same as the length of config_range, " \
+            f"but at {lam=} get {data_this_lam.shape[0]=} and {len(config_range)=}."
+
+    """ cut natmax to the number of atoms in the structure """
+    for idx, idx_in_full_dataset in enumerate(config_range):
+        this_data = {}
+        this_natoms = natoms[idx]
+        for lam, data_this_lam in data.items():
+            this_data[lam] = data_this_lam[idx, :this_natoms]  # shape (natom, [2*lambda+1,] featsize)
+        with open(osp.join(dpath, f"descriptor_{idx_in_full_dataset+1}.npz"), "wb") as f:  # index starts from 1
+            np.savez(f, **this_data)
 
 
 if __name__ == "__main__":

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -20,7 +20,6 @@ from salted.sys_utils import (
     get_atom_idx,
     get_conf_range,
     get_feats_projs,
-    get_natmax_in_range,
     read_system,
 )
 
@@ -499,10 +498,10 @@ def save_pred_descriptor(data:Dict[int, np.ndarray], config_range:List[int], nat
 
     """ cut natmax to the number of atoms in the structure """
     for idx, idx_in_full_dataset in enumerate(config_range):
-        this_data = {}
+        this_data:Dict[int, np.ndarray] = dict()
         this_natoms = natoms[idx]
         for lam, data_this_lam in data.items():
-            this_data[lam] = data_this_lam[idx, :this_natoms]  # shape (natom, [2*lambda+1,] featsize)
+            this_data[f"lam{lam}"] = data_this_lam[idx, :this_natoms]  # shape (natom, [2*lambda+1,] featsize)
         with open(osp.join(dpath, f"descriptor_{idx_in_full_dataset+1}.npz"), "wb") as f:  # index starts from 1
             np.savez(f, **this_data)
 

--- a/salted/rkhs_vector.py
+++ b/salted/rkhs_vector.py
@@ -46,30 +46,30 @@ def build():
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
-    # # TODO: replace class arraylist with numpy.concatenate
-    # # define a numpy equivalent to an appendable list
-    # class arraylist:
-    #     def __init__(self):
-    #         self.data = np.zeros((100000,))
-    #         self.capacity = 100000
-    #         self.size = 0
+    # TODO: replace class arraylist with numpy.concatenate
+    # define a numpy equivalent to an appendable list
+    class arraylist:
+        def __init__(self):
+            self.data = np.zeros((100000,))
+            self.capacity = 100000
+            self.size = 0
 
-    #     def update(self, row):
-    #         n = row.shape[0]
-    #         self.add(row,n)
+        def update(self, row):
+            n = row.shape[0]
+            self.add(row,n)
 
-    #     def add(self, x, n):
-    #         if self.size+n >= self.capacity:
-    #             self.capacity *= 2
-    #             newdata = np.zeros((self.capacity,))
-    #             newdata[:self.size] = self.data[:self.size]
-    #             self.data = newdata
+        def add(self, x, n):
+            if self.size+n >= self.capacity:
+                self.capacity *= 2
+                newdata = np.zeros((self.capacity,))
+                newdata[:self.size] = self.data[:self.size]
+                self.data = newdata
 
-    #         self.data[self.size:self.size+n] = x
-    #         self.size += n
+            self.data[self.size:self.size+n] = x
+            self.size += n
 
-    #     def finalize(self):
-    #         return self.data[:self.size]
+        def finalize(self):
+            return self.data[:self.size]
 
     fdir = f"rkhs-vectors_{saltedname}"
 
@@ -305,12 +305,12 @@ def build():
         # build sparse feature-vector memory efficiently
         nrows = Tsize
         ncols = totsize
-        # srows = arraylist()
-        # scols = arraylist()
-        # psi_nonzero = arraylist()
-        srows:List[np.ndarray] = []
-        scols:List[np.ndarray] = []
-        psi_nonzero:List[np.ndarray] = []
+        srows = arraylist()
+        scols = arraylist()
+        psi_nonzero = arraylist()
+        # srows:List[np.ndarray] = []
+        # scols:List[np.ndarray] = []
+        # psi_nonzero:List[np.ndarray] = []
         i = 0
         for iat in range(natoms[iconf]):
             spe = atomic_symbols[iconf][iat]
@@ -322,24 +322,24 @@ def build():
                 # vals = x[x!=0]
                 vals = x[nz]  # 1d array
                 for n in range(nmax[(spe,l)]):
-                    # psi_nonzero.update(vals)
-                    # srows.update(nz[0]+i)
-                    # scols.update(nz[1]+cuml_Mcut[(spe,l,n)])
-                    psi_nonzero.append(vals)
-                    srows.append(nz[0] + i)
-                    scols.append(nz[1] + cuml_Mcut[(spe,l,n)])
+                    psi_nonzero.update(vals)
+                    srows.update(nz[0]+i)
+                    scols.update(nz[1]+cuml_Mcut[(spe,l,n)])
+                    # psi_nonzero.append(vals)
+                    # srows.append(nz[0] + i)
+                    # scols.append(nz[1] + cuml_Mcut[(spe,l,n)])
                     i += 2*l+1
             ispe[spe] += 1
 
-        # psi_nonzero = psi_nonzero.finalize()
-        # srows = srows.finalize()
-        # scols = scols.finalize()
-        # ij = np.vstack((srows,scols))
-        psi_nonzero = np.concatenate(psi_nonzero, axis=0)
-        ij = np.vstack((
-            np.concatenate(srows, axis=0),
-            np.concatenate(scols, axis=0)
-        ))
+        psi_nonzero = psi_nonzero.finalize()
+        srows = srows.finalize()
+        scols = scols.finalize()
+        ij = np.vstack((srows,scols))
+        # psi_nonzero = np.concatenate(psi_nonzero, axis=0)
+        # ij = np.vstack((
+        #     np.concatenate(srows, axis=0),
+        #     np.concatenate(scols, axis=0)
+        # ))
 
         del srows
         del scols

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import h5py
 import numpy as np
 import yaml
+from ase import Atoms
 from ase.io import read
 
 from salted import basis
@@ -100,7 +101,7 @@ def get_atom_idx(ndata,natoms,spelist,atomic_symbols):
 
     return atom_idx,natom_dict
 
-def get_conf_range(rank,size,ntest,testrangetot):
+def get_conf_range(rank,size,ntest,testrangetot) -> List[List[int]]:
     if rank == 0:
         testrange = [[] for _ in range(size)]
         blocksize = int(ntest/float(size))
@@ -419,6 +420,7 @@ class ParseConfig:
                 "filename": (False, PLACEHOLDER, str, lambda inp, val: check_path_exists(val)),  # path to the prediction file
                 "predname": (False, PLACEHOLDER, str, None),  # SALTED prediction identifier
                 #### below are optional, but required for some qmcode ####
+                "save_descriptor": (False, False, bool, None),  # whether saving the descriptor
                 "predict_data": (False, PLACEHOLDER, str, lambda inp, val: check_with_qmcode(inp, val, "aims")),  # path to the prediction data by QM code, only for AIMS
             },
             "descriptor": {


### PR DESCRIPTION
The `arraylist` has been restored, will benchmark the performance later
>  The class `arraylist` in `rkhs_vector.py` is not a optimal code implementation, it is changed to `numpy.concatenate(List[arr])`

In `prediction.py` I enabled saving descriptor, and also changed the `natmax` from max number of atoms in the whole dataset to the max number of atoms in the structures to be computed in this MPI task for saving memory.