### PR TITLE
fix wigner type int problem

### DIFF
--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -176,7 +176,7 @@ def build():
 
         if rank == 0: print(f"lambda = {lam}")
 
-        [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+        llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
         wigner3j = np.loadtxt(osp.join(

--- a/salted/rkhs_vector.py
+++ b/salted/rkhs_vector.py
@@ -131,7 +131,7 @@ def build():
         power = {}
         for lam in range(lmax_max+1):
 
-            [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+            llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
             # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
             wigner3j = np.loadtxt(os.path.join(

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -70,7 +70,7 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
     
         equistart = time.time()
     
-        [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+        llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
  
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
         wigner3j = np.loadtxt(os.path.join(

--- a/salted/scalar_vector.py
+++ b/salted/scalar_vector.py
@@ -55,7 +55,7 @@ def build():
     conf_range = range(ndata)
 
     lam = 0
-    [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+    llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
     # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
     wigner3j = np.loadtxt(os.path.join(

--- a/salted/sparse_descriptor.py
+++ b/salted/sparse_descriptor.py
@@ -99,7 +99,7 @@ def build():
             if sparsify:
                 featsize = ncut
             else:
-                [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+                llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
                 featsize = nspe1*nspe2*nrad1*nrad2*llmax
             if lam==0:
                 power_env_sparse[(spe,lam)] = np.zeros((Mspe[spe],featsize))
@@ -123,7 +123,7 @@ def build():
         # Compute equivariant features for the given structure
         for lam in range(lmax_max+1):
 
-            [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+            llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
             # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
             wigner3j = np.loadtxt(os.path.join(

--- a/salted/sparsify_features.py
+++ b/salted/sparsify_features.py
@@ -78,7 +78,7 @@ def build():
 
         print("lambda =", lam)
 
-        [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+        llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
         # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
         wigner3j = np.loadtxt(osp.join(saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"))
@@ -119,7 +119,7 @@ def build():
 
         if saltedtype=="density-response" and lam>0 and lam<lmax_max:
 
-            [llmax,llvec] = sph_utils.get_angular_indexes_antisymmetric(lam,nang1,nang2)
+            llmax, llvec = sph_utils.get_angular_indexes_antisymmetric(lam,nang1,nang2)
 
             # Load the relevant Wigner-3J symbols associated with the given triplet (lam, lmax1, lmax2)
             wigner3j = np.loadtxt(osp.join(saltedpath, "wigners", f"wigner_antisymm_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"))

--- a/salted/sph_utils.py
+++ b/salted/sph_utils.py
@@ -1,5 +1,7 @@
 import sys
 import math
+from typing import Tuple
+
 import numpy as np
 from scipy import special
 from ase.data import atomic_numbers
@@ -86,7 +88,7 @@ def complex_to_real_transformation(sizes):
 
     return matrices
 
-def get_angular_indexes_symmetric(lam,nang1,nang2):
+def get_angular_indexes_symmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]:
     """Select relevant angular indexes for equivariant descriptor calculation"""
 
     llmax = 0
@@ -107,9 +109,9 @@ def get_angular_indexes_symmetric(lam,nang1,nang2):
         llvec[il,0] = lvalues[il][0]
         llvec[il,1] = lvalues[il][1]
 
-    return [llmax,llvec]
+    return llmax, llvec
 
-def get_angular_indexes_antisymmetric(lam,nang1,nang2):
+def get_angular_indexes_antisymmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]:
     """Select relevant angular indexes for equivariant descriptor calculation, antisymmetric with respect to inversion operations"""
 
     llmax = 0
@@ -130,7 +132,7 @@ def get_angular_indexes_antisymmetric(lam,nang1,nang2):
         llvec[il,0] = lvalues[il][0]
         llvec[il,1] = lvalues[il][1]
 
-    return [llmax,llvec]
+    return llmax, llvec
 
 def get_representation_coeffs(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe,species,nang,nrad,natoms):
     """Compute spherical harmonics expansion coefficients of the given structural representation."""

--- a/salted/wigner.py
+++ b/salted/wigner.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import os.path as osp
+import io
 
 import ase
 import numpy as np
@@ -24,12 +25,12 @@ def build():
     if not os.path.exists(dirpath):
         os.mkdir(dirpath)
 
-    def get_wigner3j(llmax,llvec,lam,wig):
+    def get_wigner3j(llmax:int, llvec:np.ndarray, lam:int, wig:io.TextIOWrapper):
         """Compute and save Wigner-3J symbols needed for symmetry-adapted combination"""
 
         for il in range(llmax):
-            l1 = llvec[il,0]
-            l2 = llvec[il,1]
+            l1 = int(llvec[il,0])
+            l2 = int(llvec[il,1])
             for imu in range(2*lam+1):
                 mu = imu-lam
                 for im1 in range(2*l1+1):
@@ -37,14 +38,15 @@ def build():
                     m2 = m1-mu
                     if abs(m2) <= l2:
                         im2 = m2+l2
+                        # for wigner_3j, all the parameters should be integers or half-integers
                         w3j = wigner_3j(lam,l2,l1,mu,m2,-m1) * (-1.0)**(m1)
-                        print(float(w3j),file=wig) 
-    
+                        print(float(w3j),file=wig)
+
     for lam in range(lmax_max+1):
 
         print(f"wigners: lambda = {lam}")
 
-        [llmax,llvec] = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
+        llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam,nang1,nang2)
 
         wig = open(osp.join(
             inp.salted.saltedpath, "wigners", f"wigner_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"
@@ -54,7 +56,7 @@ def build():
 
         if inp.salted.saltedtype=="density-response" and lam>0 and lam<lmax_max:
 
-            [llmax,llvec] = sph_utils.get_angular_indexes_antisymmetric(lam,nang1,nang2)
+            llmax, llvec = sph_utils.get_angular_indexes_antisymmetric(lam,nang1,nang2)
 
             wig = open(osp.join(
                 inp.salted.saltedpath, "wigners", f"wigner_antisymm_lam-{lam}_lmax1-{nang1}_lmax2-{nang2}.dat"


### PR DESCRIPTION
Here I fixed the wigner problem.

Problem: we passed `numpy.int` into `sympy.physics.wigner.wigner_3j` but it requires `int` or half-`int`
Error:
```text
>>> python -m salted.initialize
wigners: lambda = 0
Traceback (most recent call last):
  File "/u/zklou/conda-envs/salted_test/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/u/zklou/conda-envs/salted_test/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/viper/u/zklou/projects/salted_repos/SALTED_conda_env_salted_test/salted/initialize.py", line 31, in <module>
    build()
  File "/viper/u/zklou/projects/salted_repos/SALTED_conda_env_salted_test/salted/initialize.py", line 13, in build
    wigner.build()
  File "/viper/u/zklou/projects/salted_repos/SALTED_conda_env_salted_test/salted/wigner.py", line 52, in build
    get_wigner3j(llmax,llvec,lam,wig)
  File "/viper/u/zklou/projects/salted_repos/SALTED_conda_env_salted_test/salted/wigner.py", line 40, in get_wigner3j
    w3j = wigner_3j(lam,l2,l1,mu,m2,-m1) * (-1.0)**(m1)
  File "/u/zklou/conda-envs/salted_test/lib/python3.10/site-packages/sympy/physics/wigner.py", line 219, in wigner_3j
    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint,
  File "/u/zklou/conda-envs/salted_test/lib/python3.10/site-packages/sympy/physics/wigner.py", line 127, in _int_or_halfint
    raise ValueError("expecting integer or half-integer, got %s" % value)
ValueError: expecting integer or half-integer, got 0
```
Fixing: embrace `numpy.int` by `int()`, and add some typing hints
After fixing:
```
>>> python -m salted.initialize
wigners: lambda = 0
wigners: lambda = 1
wigners: lambda = 2
wigners: lambda = 3
wigners: lambda = 4
time =  0.030196428298950195
```
BTW I replaced some list returns by tuples, just want to follow the so-called conventions lol.