### PR TITLE
fix for deprecated numpy.distutils and update for featomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 LIBDIR = salted/lib
 dummy_build_folder := $(shell mkdir -p $(LIBDIR))
 
-F2PYEXE := $(shell which f2py3 || which f2py)  # simple expansion, not recursive, won't be re-evaluated
+F2PYEXE := $(shell which f2py || which f2py3)  # simple expansion, not recursive, won't be re-evaluated
 
 FCOMPILER='gfortran'
 F90FLAGS='-fopenmp'
@@ -30,61 +30,61 @@ f2py: salted/lib/ovlp2c.so salted/lib/ovlp3c.so salted/lib/ovlp2cXYperiodic.so s
 #salted/lib/gausslegendre.so salted/lib/neighlist_ewald.so salted/lib/nearfield_ewald.so salted/lib/lebedev.so
 
 salted/lib/ovlp2c.so: src/ovlp2c.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp2c.f90 -m ovlp2c --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2c.*.so ovlp2c.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp2c.f90 -m ovlp2c --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2c.*.so ovlp2c.so
 
 salted/lib/ovlp3c.so: src/ovlp3c.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp3c.f90 -m ovlp3c --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3c.*.so ovlp3c.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp3c.f90 -m ovlp3c --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3c.*.so ovlp3c.so
 
 salted/lib/ovlp2cXYperiodic.so: src/ovlp2cXYperiodic.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp2cXYperiodic.f90 -m ovlp2cXYperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2cXYperiodic.*.so ovlp2cXYperiodic.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp2cXYperiodic.f90 -m ovlp2cXYperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2cXYperiodic.*.so ovlp2cXYperiodic.so
 
 salted/lib/ovlp3cXYperiodic.so: src/ovlp3cXYperiodic.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp3cXYperiodic.f90 -m ovlp3cXYperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3cXYperiodic.*.so ovlp3cXYperiodic.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp3cXYperiodic.f90 -m ovlp3cXYperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3cXYperiodic.*.so ovlp3cXYperiodic.so
 
 salted/lib/ovlp2cnonperiodic.so: src/ovlp2cnonperiodic.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp2cnonperiodic.f90 -m ovlp2cnonperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2cnonperiodic.*.so ovlp2cnonperiodic.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp2cnonperiodic.f90 -m ovlp2cnonperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp2cnonperiodic.*.so ovlp2cnonperiodic.so
 
 salted/lib/ovlp3cnonperiodic.so: src/ovlp3cnonperiodic.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/ovlp3cnonperiodic.f90 -m ovlp3cnonperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3cnonperiodic.*.so ovlp3cnonperiodic.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/ovlp3cnonperiodic.f90 -m ovlp3cnonperiodic --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv ovlp3cnonperiodic.*.so ovlp3cnonperiodic.so
 
 salted/lib/equicomb.so: src/equicomb.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/equicomb.f90 -m equicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicomb.*.so equicomb.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicomb.f90 -m equicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicomb.*.so equicomb.so
 
 salted/lib/equicombfield.so: src/equicombfield.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/equicombfield.f90 -m equicombfield --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombfield.*.so equicombfield.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicombfield.f90 -m equicombfield --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombfield.*.so equicombfield.so
 
 salted/lib/equicombsparse.so: src/equicombsparse.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/equicombsparse.f90 -m equicombsparse --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombsparse.*.so equicombsparse.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicombsparse.f90 -m equicombsparse --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombsparse.*.so equicombsparse.so
 
 salted/lib/antiequicomb.so: src/antiequicomb.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/antiequicomb.f90 -m antiequicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicomb.*.so antiequicomb.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/antiequicomb.f90 -m antiequicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicomb.*.so antiequicomb.so
 
 salted/lib/antiequicombsparse.so: src/antiequicombsparse.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/antiequicombsparse.f90 -m antiequicombsparse --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicombsparse.*.so antiequicombsparse.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/antiequicombsparse.f90 -m antiequicombsparse --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicombsparse.*.so antiequicombsparse.so
 
 salted/lib/equicombnonorm.so: src/equicombnonorm.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/equicombnonorm.f90 -m equicombnonorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombnonorm.*.so equicombnonorm.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicombnonorm.f90 -m equicombnonorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombnonorm.*.so equicombnonorm.so
 
 salted/lib/antiequicombnonorm.so: src/antiequicombnonorm.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/antiequicombnonorm.f90 -m antiequicombnonorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicombnonorm.*.so antiequicombnonorm.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/antiequicombnonorm.f90 -m antiequicombnonorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv antiequicombnonorm.*.so antiequicombnonorm.so
 
 salted/lib/kernelequicomb.so: src/kernelequicomb.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/kernelequicomb.f90 -m kernelequicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv kernelequicomb.*.so kernelequicomb.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/kernelequicomb.f90 -m kernelequicomb --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv kernelequicomb.*.so kernelequicomb.so
 
 salted/lib/kernelnorm.so: src/kernelnorm.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/kernelnorm.f90 -m kernelnorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv kernelnorm.*.so kernelnorm.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/kernelnorm.f90 -m kernelnorm --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv kernelnorm.*.so kernelnorm.so
 
 salted/lib/equicombfps.so: src/equicombfps.f90
-	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/equicombfps.f90 -m equicombfps --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombfps.*.so equicombfps.so
+	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicombfps.f90 -m equicombfps --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombfps.*.so equicombfps.so
 
 #salted/lib/gausslegendre.so: src/gausslegendre.f90
-#	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/gausslegendre.f90 -m gausslegendre --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv gausslegendre.*.so gausslegendre.so
+#	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/gausslegendre.f90 -m gausslegendre --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv gausslegendre.*.so gausslegendre.so
 #
 #salted/lib/neighlist_ewald.so: src/neighlist_ewald.f90
-#	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/neighlist_ewald.f90 -m neighlist_ewald --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv neighlist_ewald.*.so neighlist_ewald.so
+#	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/neighlist_ewald.f90 -m neighlist_ewald --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv neighlist_ewald.*.so neighlist_ewald.so
 #
 #salted/lib/nearfield_ewald.so: src/nearfield_ewald.f90
-#	cd salted/lib; $(F2PYEXE) -c --opt=$(F2PYOPT) ../../src/nearfield_ewald.f90 -m nearfield_ewald --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv nearfield_ewald.*.so nearfield_ewald.so
+#	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/nearfield_ewald.f90 -m nearfield_ewald --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv nearfield_ewald.*.so nearfield_ewald.so
 #
 #salted/lib/lebedev.so:
 #	cd salted/lib; $(CC) -fPIC -shared -o lebedev.so ../../src/Lebedev-Laikov.c

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 SALTED: Symmetry-Adapted Learning of Three-dimensional Electron Densities
 =========================================================================
-This repository contains an implementation of symmetry-adapted Gaussian Process Regression suitable to perform equivariant learning and prediction of the electron density of molecular and condensed-phase systems, together with its static linear response function to applied electric fields. This is done by representing the continuous scalar (density) and vector (density-response) fields on a linear basis of atom-centered radial functions and spherical harmonics basis.
+This repository contains an implementation of symmetry-adapted Gaussian Process Regression suitable to perform equivariant learning and prediction of the electron density of molecular and condensed-phase systems, together with its static linear response function to applied electric fields. This is done by representing the continuous scalar (density) and vector (density-response) fields on a linear basis of atom-centered radial functions and spherical harmonics.
 
 Documentation
 -------------
@@ -39,7 +39,7 @@ Input file
 ----------
 SALTED input is provided in a :code:`inp.yaml` file, which is structured in the following sections:
 
-- :code:`salted` (required): define root storage directory and workflow label 
+- :code:`salted` (required): define root storage directory, workflow label and learning target 
 
 - :code:`system` (required): define system parameters 
 

--- a/README.rst
+++ b/README.rst
@@ -23,15 +23,17 @@ In the SALTED directory, simply run :code:`make`, followed by :code:`pip install
 Dependencies
 ------------
 
---> **rascaline**: rascaline installation requires a RUST compiler. To install a RUST compiler, run:
+--> **featomic**: featomic installation requires a RUST compiler. To install a RUST compiler, run:
 :code:`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`
-rascaline can then be installed using
-:code:`pip install git+https://github.com/Luthaf/rascaline.git`
+featomic can then be installed using
+:code:`pip install git+https://github.com/metatensor/featomic`
 
 --> **mpi4py**: mpi4py is required to use MPI parallelisation; SALTED can nonetheless be run without this.
 A parallel h5py installation is required to use MPI parellelisation. This can be installed by running:
 :code:`HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py`
 provided HDF5 has been compiled with MPI support.
+
+--> :code: `pip install meson ninja` to run f2py using meson backend following versions of Python > 3.12.
 
 Input file
 ----------
@@ -115,6 +117,3 @@ andrea.grisafi@ens.psl.eu
 
 alan.m.lewis@york.ac.uk
 
-Contributors
-------------
-Andrea Grisafi, Alan Lewis, Zekun Lou, Mariana Rossi

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 SALTED: Symmetry-Adapted Learning of Three-dimensional Electron Densities
 =========================================================================
-This repository contains an implementation of symmetry-adapted Gaussian Process Regression suitable to perform equivariant predictions of the electron density of both molecular and condensed-phase systems, as decomposed on an atom-centered spherical harmonics basis.
+This repository contains an implementation of symmetry-adapted Gaussian Process Regression suitable to perform equivariant learning and prediction of the electron density of molecular and condensed-phase systems, together with its static linear response function to applied electric fields. This is done by representing the continuous scalar (density) and vector (density-response) fields on a linear basis of atom-centered radial functions and spherical harmonics basis.
 
 Documentation
 -------------
@@ -53,8 +53,8 @@ SALTED input is provided in a :code:`inp.yaml` file, which is structured in the 
 
 Input Dataset
 -------------
-Input structures are required in extXYZ format; the corresponding filename must be specified in the :code:`inp.system.filename`. 
-Electron density training data consists in the expansion coefficients of the scalar field over atom-centered basis functions made of radial functions and spherical harmonics. These coefficients are computed following density-fitting (DF), a.k.a. resolution of the identity, approximations, commonly applied in electronic-structure codes. We assume to work with orthonormalized real spherical harmonics defined with the Condon-Shortley phase convention. No restriction is instead imposed on the nature of the radial functions. Because of the non-orthogonality of the basis functions, the 2-center electronic integral matrices associated with the given density-fitting approximation are also required as input. 
+Input structures are required in extXYZ format; the corresponding filename must be specified in the :code:`inp.system.filename`.  
+Training data consists in the expansion coefficients of the scalar/vector field over atom-centered basis functions made of radial functions and spherical harmonics. These coefficients are computed following density-fitting (DF), a.k.a. resolution of the identity, approximations, commonly applied in electronic-structure codes. We assume to work with orthonormalized real spherical harmonics defined with the Condon-Shortley phase convention. No restriction is instead imposed on the nature of the radial functions. Because of the non-orthogonality of the basis functions, the 2-center electronic integral matrices associated with the given density-fitting approximation are also required as input. 
 The electronic-structure codes that are to date interfaced with SALTED are:
     
    - **FHI-aims**
@@ -65,7 +65,7 @@ We refer to the code-specific examples for how to produce the required quantum-m
 
 Usage
 -----
-The root directory used for storing SALTED data is specified in :code:`inp.salted.saltedpath`. Depending on the chosen input parameters, a SALTED workflow can be labelled adding a coherent string in the :code:`inp.salted.saltedname` variable; in turn, this defines the name of the output folders that are automatically generated during the program execution. SALTED functions can be run either by importing the corresponding modules in Python, or directly from command line. 
+The root directory used for storing SALTED data is specified in :code:`inp.salted.saltedpath`. Depending on the chosen input parameters, a SALTED workflow can be labelled adding a coherent string in the :code:`inp.salted.saltedname` variable; in turn, this defines the name of the output folders that are automatically generated during the program execution. The type of SALTED target can be selected by specifying :code:`inp.salted.saltedtype: density`, when asking to learn electron density, or :code:`inp.salted.saltedtype: density-response`, when asking to learn the electron-density linear response to applied electric fields. SALTED functions can be run either by importing the corresponding modules in Python, or directly from command line. 
 MPI parallelization can be activated by setting :code:`inp.system.parallel` as :code:`True`, and can be used, whenever applicable, to parallelize the calculation of SALTED functions over training data. 
 In what follows, we report an example of a general command line workflow: 
 
@@ -99,7 +99,7 @@ In what follows, we report an example of a general command line workflow:
 
    :code:`python3 -m salted.solve_regression`
 
-   NB: when the dimensionality exceeds $10^5$, it is recommended to perform a direct minimization of the SALTED loss function in place of an explicit matrix inversion (points 6 and 7). If the dimensionality exceeds $70000$, the loss function must be minimized directly. This can be run as follows:
+   NB: when the dimensionality exceeds $10^5$, it is recommended to perform a direct minimization of the SALTED loss function in place of an explicit matrix inversion (points 6 and 7). If the dimensionality exceeds $10^5$, the loss function must be minimized directly. This can be run as follows:
 
    :code:`python3 -m salted.minimize_loss` (MPI parallelizable)
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Dependencies
 --> **featomic**: featomic installation requires a RUST compiler. To install a RUST compiler, run:
 :code:`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`
 featomic can then be installed using
-:code:`pip install git+https://github.com/metatensor/featomic`
+:code:`pip install git+https://github.com/metatensor/featomic.git`
 
 --> **mpi4py**: mpi4py is required to use MPI parallelisation; SALTED can nonetheless be run without this.
 A parallel h5py installation is required to use MPI parellelisation. This can be installed by running:

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ A parallel h5py installation is required to use MPI parellelisation. This can be
 :code:`HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py`
 provided HDF5 has been compiled with MPI support.
 
---> :code: `pip install meson ninja` to run f2py using meson backend following versions of Python > 3.12.
+--> :code: `pip install meson ninja` to run f2py using meson backend following versions of Python >= 3.12.
 
 Input file
 ----------

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,9 +20,11 @@ You can find the SALTED program on [GitHub](https://github.com/andreagrisafi/SAL
 
 ### Dependencies
 
- - `rascaline`: rascaline installation requires a RUST compiler. To install a RUST compiler, run: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`. rascaline can then be installed using `pip install git+https://github.com/Luthaf/rascaline.git`.
+ - `featomic`: featomic installation requires a RUST compiler. To install a RUST compiler, run: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`. featomic can then be installed using `pip install git+https://github.com/`metatensor/featomic.git`.
 
  - `mpi4py`: mpi4py is required to use MPI parallelisation; SALTED can nonetheless be run without this. A parallel h5py installation is required to use MPI parellelisation. This can be installed by running: `HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py` provided HDF5 has been compiled with MPI support.
+
+ - `pip install meson ninja` to run f2py using meson backend following versions of Python > 3.12.
 
 ## Install electronic-structure codes 
 
@@ -49,4 +51,4 @@ Especially, you can find an FHI-aims focused tutorial on SALTED [here in FHI-aim
 
 ### CP2K
 
-Printing of density coefficients and 2-center auxiliary integrals needed to train SALTED is made available starting from the v2023.1 release of CP2K.
+Printing of RI density coefficients and 2-center auxiliary integrals needed to train SALTED is made available starting from the v2023.1 release of CP2K.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ You can find the SALTED program on [GitHub](https://github.com/andreagrisafi/SAL
 
 ### Dependencies
 
- - `featomic`: featomic installation requires a RUST compiler. To install a RUST compiler, run: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`. featomic can then be installed using `pip install git+https://github.com/`metatensor/featomic.git`.
+ - `featomic`: featomic installation requires a RUST compiler. To install a RUST compiler, run: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source "$HOME/.cargo/env"`. featomic can then be installed using `pip install git+https://github.com/metatensor/featomic.git`.
 
  - `mpi4py`: mpi4py is required to use MPI parallelisation; SALTED can nonetheless be run without this. A parallel h5py installation is required to use MPI parellelisation. This can be installed by running: `HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py` provided HDF5 has been compiled with MPI support.
 

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -118,7 +118,7 @@ def build():
 
     start = time.time()
 
-    start_rascaline = time.time()
+    start_featomic = time.time()
 
     # Read frames
     frames = read(filename_pred,":")
@@ -132,7 +132,7 @@ def build():
     v1 = np.transpose(omega1,(2,0,3,1))
     v2 = np.transpose(omega2,(2,0,3,1))
     
-    print("rascaline time (sec) = ",time.time()-start_rascaline,flush=True)
+    print("featomic time (sec) = ",time.time()-start_featomic,flush=True)
 
     if saltedtype=="density":
 

--- a/salted/sph_utils.py
+++ b/salted/sph_utils.py
@@ -6,8 +6,8 @@ import numpy as np
 from scipy import special
 from ase.data import atomic_numbers
 
-from rascaline import SphericalExpansion
-from rascaline import LodeSphericalExpansion
+from featomic import SphericalExpansion
+from featomic import LodeSphericalExpansion
 from metatensor import Labels
 
 def cartesian_to_spherical_transformation(l):

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -434,24 +434,66 @@ class ParseConfig:
         nspe1 = len(inp.descriptor.rep1.neighspe)
         nspe2 = len(inp.descriptor.rep2.neighspe)
 
+        #HYPER_PARAMETERS_DENSITY = {
+        #    "cutoff": inp.descriptor.rep1.rcut,
+        #    "max_radial": inp.descriptor.rep1.nrad,
+        #    "max_angular": inp.descriptor.rep1.nang,
+        #    "atomic_gaussian_width": inp.descriptor.rep1.sig,
+        #    "center_atom_weight": 1.0,
+        #    "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
+        #    "cutoff_function": {"ShiftedCosine": {"width": 0.1}},
+        #}
+
         HYPER_PARAMETERS_DENSITY = {
-            "cutoff": inp.descriptor.rep1.rcut,
-            "max_radial": inp.descriptor.rep1.nrad,
-            "max_angular": inp.descriptor.rep1.nang,
-            "atomic_gaussian_width": inp.descriptor.rep1.sig,
-            "center_atom_weight": 1.0,
-            "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
-            "cutoff_function": {"ShiftedCosine": {"width": 0.1}},
+                   "cutoff": {
+                       "radius": inp.descriptor.rep1.rcut,
+                       "smoothing": {
+                           "type": "ShiftedCosine",
+                           "width": 0.1
+                       }
+                   },
+                   "density": {
+                       "type": "Gaussian",
+                       "width": inp.descriptor.rep1.sig
+                   },
+                   "basis": {
+                       "type": "TensorProduct",
+                       "max_angular": inp.descriptor.rep1.nang,
+                       "radial": {
+                           "type": "Gto",
+                           "max_radial": inp.descriptor.rep1.nrad-1
+                       },
+                       "spline_accuracy": 1e-06
+                   }
         }
 
+        #HYPER_PARAMETERS_POTENTIAL = {
+        #    "potential_exponent": 1,
+        #    "cutoff": inp.descriptor.rep2.rcut,
+        #    "max_radial": inp.descriptor.rep2.nrad,
+        #    "max_angular": inp.descriptor.rep2.nang,
+        #    "atomic_gaussian_width": inp.descriptor.rep2.sig,
+        #    "center_atom_weight": 1.0,
+        #    "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
+        #}
+
         HYPER_PARAMETERS_POTENTIAL = {
-            "potential_exponent": 1,
-            "cutoff": inp.descriptor.rep2.rcut,
-            "max_radial": inp.descriptor.rep2.nrad,
-            "max_angular": inp.descriptor.rep2.nang,
-            "atomic_gaussian_width": inp.descriptor.rep2.sig,
-            "center_atom_weight": 1.0,
-            "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
+
+            "density": {
+                "type": "SmearedPowerLaw",
+                "smearing": inp.descriptor.rep2.sig,
+                "exponent": 1
+            },
+            "basis": {
+                "type": "TensorProduct",
+                "max_angular": inp.descriptor.rep2.nang,
+                "radial": {
+                    "type": "Gto",
+                    "max_radial": inp.descriptor.rep2.nrad-1,
+                    "radius": inp.descriptor.rep2.rcut
+                },
+                "spline_accuracy": 1e-06
+            }
         }
 
         return (

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author_email='andrea.grisafi@ens.psl.eu, alan.m.lewis@york.ac.uk',
     license='GNU GENERAL PUBLIC LICENSE',
     packages=['salted','salted.cp2k','salted.pyscf','salted.aims','salted.lib'],
-    install_requires=['mpi4py','rascaline','ase','numpy','scipy','h5py','sympy','pyyaml'],
+    install_requires=['mpi4py','featomic','ase','numpy','scipy','h5py','sympy','pyyaml'],
     include_package_data=True,
     package_data={"salted": ["salted/lib/*.so"]},
     classifiers=[


### PR DESCRIPTION
 Update Makefile with f2py --backend meson in order to avoid using deprecated numpy.distutils in Python3.12+.

Update rascaline with featomic together with new hypers definition.