### PR TITLE
Add OpenMP-accelerated sparse matrix operations for Hessian computation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CC=gcc
 init:
 	cd salted/lib; touch __init__.py
 
-f2py: salted/lib/ovlp2c.so salted/lib/ovlp3c.so salted/lib/ovlp2cXYperiodic.so salted/lib/ovlp3cXYperiodic.so salted/lib/ovlp2cnonperiodic.so salted/lib/ovlp3cnonperiodic.so salted/lib/equicomb.so salted/lib/equicombfield.so salted/lib/equicombsparse.so salted/lib/antiequicomb.so salted/lib/antiequicombsparse.so salted/lib/equicombnonorm.so salted/lib/antiequicombnonorm.so salted/lib/kernelequicomb.so salted/lib/kernelnorm.so salted/lib/equicombfps.so
+f2py: salted/lib/ovlp2c.so salted/lib/ovlp3c.so salted/lib/ovlp2cXYperiodic.so salted/lib/ovlp3cXYperiodic.so salted/lib/ovlp2cnonperiodic.so salted/lib/ovlp3cnonperiodic.so salted/lib/equicomb.so salted/lib/equicombfield.so salted/lib/equicombsparse.so salted/lib/antiequicomb.so salted/lib/antiequicombsparse.so salted/lib/equicombnonorm.so salted/lib/antiequicombnonorm.so salted/lib/kernelequicomb.so salted/lib/kernelnorm.so salted/lib/equicombfps.so salted/lib/omp_sparse.so
 
 #salted/lib/gausslegendre.so salted/lib/neighlist_ewald.so salted/lib/nearfield_ewald.so salted/lib/lebedev.so
 
@@ -76,6 +76,9 @@ salted/lib/kernelnorm.so: src/kernelnorm.f90
 
 salted/lib/equicombfps.so: src/equicombfps.f90
 	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/equicombfps.f90 -m equicombfps --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv equicombfps.*.so equicombfps.so
+
+salted/lib/omp_sparse.so: src/omp_sparse.f90
+	cd salted/lib; env FFLAGS=$(F90FLAGS) $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/omp_sparse.f90 -m omp_sparse --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv omp_sparse.*.so omp_sparse.so
 
 #salted/lib/gausslegendre.so: src/gausslegendre.f90
 #	cd salted/lib; $(F2PYEXE) --backend meson -c --opt=$(F2PYOPT) ../../src/gausslegendre.f90 -m gausslegendre --fcompiler=$(FCOMPILER) --f90flags=$(F90FLAGS) $(LIBS); mv gausslegendre.*.so gausslegendre.so

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -841,6 +841,12 @@ class ParseConfig:
                     str,
                     lambda inp, val: val in ("random", "sequential"),
                 ),  # if shuffle the training set
+                "sparse_algorithm": (
+                    False,
+                    "omp_sparse",
+                    str,
+                    lambda inp, val: val in ("dense", "omp_sparse"),
+                )
             },
         }
 


### PR DESCRIPTION
# Add OpenMP-accelerated sparse matrix operations for Hessian computation

## Summary

This PR introduces OpenMP-accelerated sparse matrix operations to optimize the Hessian matrix computation in SALTED, addressing the primary computational bottleneck identified in issue #62. The implementation leverages the sparsity structure of the $\Psi$ matrix to achieve significant speedups, particularly for materials with lower matrix density.

## Problem

The Hessian matrix calculation $\Psi^\top S \Psi$ represents the most time-consuming step in SALTED training. Current implementation converts sparse $\Psi$ matrices to dense format before computation, losing efficiency benefits from their sparsity structure.

## Solution

### Implementation
- Integrates `omp_sparse` package for high-performance dense-sparse matrix multiplication
- Utilizes OpenMP-parallelized Fortran backend with dynamic scheduling
- Maintains sparse matrix format throughout computation
- Automatic fallback to dense computation if the `omp_sparse` package is unavailable

### Algorithm Details
- **Method**: Column-wise parallelization with vectorized inner loops
- **Format**: Optimized for CSC (Compressed Sparse Column) matrices
- **Scheduling**: OpenMP dynamic scheduling for load balancing
- **Precision**: Double precision (float64) throughout

## Performance Results

### Material-Dependent Speedups
The acceleration effectiveness correlates with matrix sparsity:

| Material | Matrix Density | Max Speedup | Optimal Threads |
|----------|---------------|-------------|-----------------|
| ZrS2     | 1.61%         | ~5.5x       | 8-16           |
| TiS2     | 1.78%         | ~4.8x       | 8-16           |
| Graphene | 5.95%         | ~1.9x       | 4-8            |

### Scalability Analysis
- **Linear scaling**: Maintains good parallel efficiency up to 8 threads
- **Memory efficiency**: depends on Menv. In the test cases, Menv=200 and the dimension D of $\Psi$ is far larger than the other dimension, leading to little memory advantage.
- **Thread scaling**: Performance plateaus beyond 16 threads, maybe due to memory bandwidth or other hardware limitations. NumPy behaves the same.

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/dcb732e1-1665-4a77-96b1-28172afdcb4e" />

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/6f0d9e48-9576-4815-a32f-81218a4dd830" />

<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/7c4d87b9-13c8-4720-b8c3-1859d6664f93" />

## Numerical Validation

### Water Monomer Test

Results from numpy_dense method:
```text
# get_df_error (for trainset)
% MAE = 0.8611622020848769

# validation
% RMSE: 9.680e-01

# get_ml_error
% MAE = 0.835204718117146

# collect_energies
Mean absolute errors (eV/atom):
Electrostatic energy: 0.010159641166615075
XC energy: 0.019076590166666563
Total energy: 0.00044581299997616954
```

Results from omp_sparse method:
```text
# get_df_error (for trainset)
% MAE = 0.8611622020848769 (same)

# validation
% RMSE: 9.680e-01 (same)

# get_ml_error
% MAE = 0.8352047181285573 (relative error < 1e-9)

# collect_energies
Mean absolute errors (eV/atom):
Electrostatic energy: 0.010159641166615075 (same)
XC energy: 0.019076590000000237 (relative error < 1e-7)
Total energy: 0.00044581299997616954 (same)
```

### Regression Weight Accuracy
Comprehensive validation confirms numerical consistency between sparse and dense methods:

#### ZrS2 Validation
Test on HPC with 10 tasks x 25 cpus per task.
The original hessian matrix computation takes 45 m 26 s, with omp_sparse it is 24 m 50 s (x1.8 acceleration).
```text
Relative RMSE between numpy and OMP weights: 1.555e-07 %
Cosine similarity between numpy and OMP weights: 1.000000e+00
Pearson correlation between numpy and OMP weights: 1.000000e+00
```
<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/c886c2a3-de87-4326-9757-f6cd3f84217d" />

#### TiS2 Validation
Test on HPC with 20 tasks x 12 cpus per task.
The original hessian matrix computation takes 36 m 45 s, with omp_sparse it is 18 m 37 s (x2 acceleration).
```text
Relative RMSE between numpy and OMP weights: 3.374e-07 %
Cosine similarity between numpy and OMP weights: 1.000000e+00
Pearson correlation between numpy and OMP weights: 1.000000e+00
```
<img width="600" height="450" alt="image" src="https://github.com/user-attachments/assets/d430c07e-3382-495a-9ae8-770606061863" />

## Usage

The acceleration is in a separate GitHub repo [omp_sparse](https://github.com/zekunlou/omp_sparse).

### Requirements
```bash
git clone https://github.com/zekunlou/omp_sparse.git
cd omp_sparse
make
pip install -e .
```

### Environment Setup
```bash
export OMP_NUM_THREADS=8  # Set to available CPU cores
```

### Integration
The implementation automatically detects `omp_sparse` availability and enables acceleration transparently. No changes to existing SALTED usage required.

