### PR TITLE
Writing SALTED model files to a binary file

### DIFF
--- a/docs/binary_models.md
+++ b/docs/binary_models.md
@@ -1,0 +1,107 @@
+# Binary Salted Models
+By running `salted_pack.py`, a single binary file is created that consolidates and serializes multiple data sources (NumPy arrays, HDF5 datasets, and model parameters) into one portable format.
+This simplifies model sharing and enables easier deployment for prediction tasks.
+
+## Usage
+### Creating binary models
+Only a single command is required to transform a newly trained and verified model into the binary `.salted` format.
+The command must be executed from the main project directory:
+
+    salted_pack.py
+
+This will generate a `.salted` file.
+
+### Deploying binary models
+Predictions using a binary model can be performed with:
+
+    predict_from_model.py
+
+**Input arguments**
+| Argument  | Meaning |
+| -------- | --------|
+| model | Path to the `.salted` model file.  |
+| xyz   | Path to the `.xyz` file containing the structure for which the prediction is performed.  |
+| -o     | Output directory for the predicted coefficients (optional, default: `predictions/`)  | 
+
+## Implementation details
+### Basic design
+All integers are little-endian signed 32-bit unless noted; all floating arrays are little-endian float64. All 5-char names are ASCII padded with NUL to 5 bytes.
+General Arrays
+
+In the following every array is encoded using the same scheme:
+
+    def encode_array(NDIMS:int, DIMS:list[int], data):
+      file.write(NDIMS)
+      for dim_size in DIMS:
+        file.write(dim_size)
+      file.write(data)
+
+This results in a datastructure as follows:
+
+    NDIMS (int32)
+    DIMS (int32 * NDIMS)
+    DATA (TYPE OF ARRAY)
+
+The Type of the given array is encoded using the numbers from 0 - 5:
+
+    int32=0
+    int64=1
+    float32=2
+    float64=3
+    str=4
+    bool=5
+
+### Sections in the file
+Now the different sections of the file are explained in more detail:
+#### Container header
+
+    MAGIC (5 bytes): b"SALTD"
+    VERSION (int32)
+    N_BLOCKS (int32)
+    TOC: N_BLOCKS entries of:
+        BLOCK_NAME (5 bytes, NUL-padded)
+        BLOCK_OFFSET (int32): file offset (from start) where the block payload begins
+
+#### AVERG, WIG, FPS, WEIGH
+
+    TYPE (int32) (datatype of the following block)
+    NFILES (int32) (number of arrays in the specific key)
+    FOR EACH FILE
+        encode_array(NDIMS, DIMS, data)
+
+#### FEATS, PROJE
+
+    TYPE (int32): float64
+    NKEYS (int32) — top-level HDF5 group count (sorted)
+    For each top-level key:
+        KEY5 (5 bytes, NUL-padded)
+        NSUB (int32) — number of datasets under this key (sorted)
+        For each sub-key dataset:
+            encode_array(NDIMS, DIMS, data)
+
+#### CONFG
+
+    For each entry in inputs (fixed order in code):
+        KEY5 (5 bytes) — e.g., b"averg", b"ncut\0", …
+        TYPE (int32)
+        VALUE encoded by VAL_TYPE:
+            bool: int32 (0 or 1)
+            int32: int32
+            float64: float64
+            str: SLEN (int32, byte length), then SLEN bytes UTF-8
+
+#### BASIS (Only if pyscf is installed)
+
+    TYPE (int32): float64 (tag for numeric arrays in this block)
+    NELEM (int32): number of elements included
+    For each element:
+        ELEM_ID (int32): PySCF element index
+        Four arrays follow, each preceded by a shape header:
+            contractions_per_shell (int32[])
+                encode_array(NDIMS, DIMS, data)
+            angular_momenta_per_shell (int32[])
+                encode_array(NDIMS, DIMS, data)
+            exponents_per_shell (float64[])
+                encode_array(NDIMS, DIMS, data)
+            coeffs_per_shell (float64[])
+                encode_array(NDIMS, DIMS, data)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -11,8 +11,10 @@ site_url: https://github.com/andreagrisafi/SALTED
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Docker: docker.md
   - Theory: theory.md
   - Workflow: workflow.md
+  - Binary Deployment: binary_models.md
   - Input: input.md
   - Tutorial:
     - Part 1 - Dataset: tutorial/dataset.md

--- a/salted/pack_model.py
+++ b/salted/pack_model.py
@@ -2,7 +2,16 @@ import h5py
 import glob, os
 import numpy as np
 
+import struct
+
+def u32(x):  return struct.pack('<I', x)
+def i32(x):  return struct.pack('<i', x)
+def i64(x):  return struct.pack('<q', x)
+def f64(x):  return struct.pack('<d', x)
+
 from salted.sys_utils import ParseConfig
+#EVERYTHING IS LITTLE ENDIAN!
+
 #FORMAT FOR SALTED FILE:
 #MAGIC_NUMBER (5 bytes, str)
 #VERSION (4 bytes, int32)
@@ -31,21 +40,27 @@ types_dict = {
 }
 OFFSET_TABLE_OF_CONTENTS = 5+4+4
 
+def first_match(pattern):
+    m = glob.glob(pattern)
+    return m[0] if m else None
+
+def write_key5(f, s: bytes):
+    if len(s) > 5:
+        raise ValueError(f"Key longer than 5 bytes: {s!r}")
+    f.write(s + b'\0' * (5 - len(s)))
 
 def write_data_head(SALTED_file, data):
-    SALTED_file.write(np.int32(data.ndim))
+    SALTED_file.write(i32(int(data.ndim)))
     for dim in data.shape:
-        SALTED_file.write(np.int32(dim))
-
+        SALTED_file.write(i32(int(dim)))
 
 
 def write_chunk_location(SALTED_file, chunk_name, location):
     global OFFSET_TABLE_OF_CONTENTS
     end_of_block = SALTED_file.tell()
     SALTED_file.seek(OFFSET_TABLE_OF_CONTENTS)
-    SALTED_file.write(chunk_name.encode("utf-8"))
-    SALTED_file.write(b'\0'*(5-len(chunk_name)))
-    SALTED_file.write(np.int32(location).tobytes())
+    write_key5(SALTED_file, chunk_name.encode("utf-8"))
+    SALTED_file.write(i32(int(location)))
     SALTED_file.seek(end_of_block)
     OFFSET_TABLE_OF_CONTENTS += 5+4
 
@@ -62,16 +77,15 @@ def write_chunk_location(SALTED_file, chunk_name, location):
 def pack_averages(SALTED_file, path):
     print("Writing Averages")
     begin_of_block = SALTED_file.tell()
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    SALTED_file.write(i32(int(types_dict["float64"])))
     files = glob.glob(os.path.join(path,"averages",'av*.npy'))
-    SALTED_file.write(np.int32(len(files)).tobytes())
+    SALTED_file.write(i32(int(len(files))))
     for file in files:
         element = os.path.basename(file).split('.')[0].split("_")[-1]
-        SALTED_file.write(element.encode("utf-8"))
-        SALTED_file.write(b'\0'*(5-len(element)))
+        write_key5(SALTED_file, element.encode("utf-8"))
         data = np.load(file).astype(np.float64)
         write_data_head(SALTED_file, data)
-        SALTED_file.write(data.tobytes())
+        SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
     write_chunk_location(SALTED_file, "AVERG", begin_of_block)
         
 
@@ -86,15 +100,15 @@ def pack_averages(SALTED_file, path):
 def pack_wigners(SALTED_file, path, inp):
     print("Writing Wigners")
     begin_of_block = SALTED_file.tell()
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    SALTED_file.write(i32(int(types_dict["float64"])))
     files = glob.glob(os.path.join(path,"wigners",f'wigner_lam-*_lmax1-{inp.descriptor.rep1.nang}_lmax2-{inp.descriptor.rep2.nang}.dat'))
     files.sort(key=lambda x: int(x.split("_")[1].split("-")[1]))
-    SALTED_file.write(np.int32(len(files)).tobytes())
+    SALTED_file.write(i32(int(len(files))))
     for file in files:
         print(file)
         data = np.loadtxt(file).astype(np.float64)
         write_data_head(SALTED_file, data)
-        SALTED_file.write(data.tobytes())
+        SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
     write_chunk_location(SALTED_file, "WIG", begin_of_block)
 
 
@@ -109,15 +123,15 @@ def pack_wigners(SALTED_file, path, inp):
 def pack_fps(SALTED_file, path, inp):
     print("Writing FPS")
     begin_of_block = SALTED_file.tell()
-    SALTED_file.write(np.int32(types_dict["int64"]).tobytes())
+    SALTED_file.write(i32(int(types_dict["int64"])))
     files = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'fps{inp.descriptor.sparsify.ncut}-*.npy'))
     files.sort(key=lambda x: int(x.split("-")[-1].split(".")[0]))
-    SALTED_file.write(np.int32(len(files)).tobytes())
+    SALTED_file.write(i32(int(len(files))))
     for file in files:
         print(file)
         data = np.load(file).astype(np.int64)
         write_data_head(SALTED_file, data)
-        SALTED_file.write(data.tobytes())
+        SALTED_file.write(np.asarray(data,dtype='<i8').tobytes())
     write_chunk_location(SALTED_file, "FPS", begin_of_block)
 
 
@@ -133,46 +147,50 @@ def pack_fps(SALTED_file, path, inp):
         #dims (4*ndims bytes, int32)
         #data (dim1*dim2*8 bytes, float64)
 def pack_projectors(SALTED_file, path, inp):
-    file_proj = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'projector_M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}.h5'))[0]
+    file_proj = first_match(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'projector_M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}.h5'))
+    if file_proj is None:
+        raise FileNotFoundError(f"No projector file found for M={inp.gpr.Menv}, zeta={inp.gpr.z} in {os.path.join(path, f'equirepr_{inp.salted.saltedname}')}")
     begin_of_block = SALTED_file.tell()
     print(f"Reading {file_proj}")
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    SALTED_file.write(i32(int(types_dict["float64"])))
     with h5py.File(file_proj, 'r') as h5file:
-        SALTED_file.write(np.int32(len(h5file["projectors"].keys())).tobytes())
-        for key in list(h5file["projectors"].keys()):
+        proje = h5file["projectors"]
+        SALTED_file.write(i32(int(len(proje.keys()))))
+        for key in sorted(proje.keys()):
             print(key, end=": ")
             #First 5 bytes are the key as string
-            SALTED_file.write(key.encode("utf-8"))
-            SALTED_file.write(b'\0'*(5-len(key)))
+            write_key5(SALTED_file, key.encode("utf-8"))
             #Write the number of sub-keys
-            SALTED_file.write(np.int32(len(h5file["projectors"][key].keys())).tobytes())
-            for key2 in h5file["projectors"][key].keys():
+            SALTED_file.write(i32(int(len(proje[key].keys()))))
+            for key2 in sorted(proje[key].keys()):
                 print(key2, end = " ")
-                data = np.array(h5file["projectors"][key][key2], dtype=np.float64)
+                data = np.array(proje[key][key2], dtype=np.float64)
                 write_data_head(SALTED_file, data)
-                SALTED_file.write(data.tobytes())
+                SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
             print()
-    write_chunk_location(SALTED_file, "PROJ", begin_of_block)
+    write_chunk_location(SALTED_file, "PROJE", begin_of_block)
 
 def pack_FEATS(SALTED_file, path, inp):
-    file_feat = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}.h5'))[0]
+    file_feat = first_match(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}_*.h5'))
+    if file_feat is None:
+        raise FileNotFoundError(f"No FEAT file found for M={inp.gpr.Menv} in {os.path.join(path, f'equirepr_{inp.salted.saltedname}')}")
     begin_of_block = SALTED_file.tell()
     print(f"Reading {file_feat}")
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    SALTED_file.write(i32(int(types_dict["float64"])))
     with h5py.File(file_feat, 'r') as h5file:
-        SALTED_file.write(np.int32(len(h5file["sparse_descriptors"].keys())).tobytes())
-        for key in list(h5file["sparse_descriptors"].keys()):
+        descr = h5file["sparse_descriptors"]
+        SALTED_file.write(i32(int(len(descr.keys()))))
+        for key in sorted(descr.keys()):
             print(key, end=": ")
             #First 5 bytes are the key as string
-            SALTED_file.write(key.encode("utf-8"))
-            SALTED_file.write(b'\0'*(5-len(key)))
+            write_key5(SALTED_file, key.encode("utf-8"))
             #Write the number of sub-keys
-            SALTED_file.write(np.int32(len(h5file["sparse_descriptors"][key].keys())).tobytes())
-            for key2 in h5file["sparse_descriptors"][key].keys():
+            SALTED_file.write(i32(int(len(descr[key].keys()))))
+            for key2 in sorted(descr[key].keys()):
                 print(key2, end = " ")
-                data = np.array(h5file["sparse_descriptors"][key][key2], dtype=np.float64)
+                data = np.array(descr[key][key2], dtype=np.float64)
                 write_data_head(SALTED_file, data)
-                SALTED_file.write(data.tobytes())
+                SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
             print()
     write_chunk_location(SALTED_file, "FEATS", begin_of_block)
 
@@ -186,59 +204,58 @@ def pack_FEATS(SALTED_file, path, inp):
     #data (ndims*8 bytes, float64)
 def pack_weights(SALTED_file, path, inp):
     begin_of_block = SALTED_file.tell()
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
-    SALTED_file.write(np.int32(1).tobytes())
-    file = glob.glob(os.path.join(path, f"regrdir_{inp.salted.saltedname}", f"M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}", f'weights_N{int(inp.gpr.Ntrain*inp.gpr.trainfrac)}_reg*'))[0]
+    SALTED_file.write(i32(int(types_dict["float64"])))
+    SALTED_file.write(i32(1))
+    file = first_match(os.path.join(path, f"regrdir_{inp.salted.saltedname}", f"M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}", f'weights_N{int(inp.gpr.Ntrain*inp.gpr.trainfrac)}_reg*'))
+    if file is None:
+        raise FileNotFoundError(f"No weights file found for M={inp.gpr.Menv}, zeta={inp.gpr.z} in {os.path.join(path, f'regrdir_{inp.salted.saltedname}')}")
     data = np.load(file).astype(np.float64)
     write_data_head(SALTED_file, data)
-    SALTED_file.write(data.tobytes())
+    SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
     write_chunk_location(SALTED_file, "WEIGH", begin_of_block)
 
 def pack_model_info(SALTED_file, inp):
-    inputs = {
-        b"averg": inp.system.average,  #Bools
-        b"spars": inp.descriptor.sparsify.ncut > 0,
-        b"ncut\0": inp.descriptor.sparsify.ncut,  #int32
-        b"nang1": inp.descriptor.rep1.nang,
-        b"nang2": inp.descriptor.rep2.nang,
-        b"nrad1": inp.descriptor.rep1.nrad,
-        b"nrad2": inp.descriptor.rep2.nrad,
-        b"Menv\0": inp.gpr.Menv,
-        b"Ntran": inp.gpr.Ntrain,
-        b"rcut1": inp.descriptor.rep1.rcut,  #float64
-        b"rcut2": inp.descriptor.rep2.rcut,
-        b"sig1\0": inp.descriptor.rep1.sig,
-        b"sig2\0": inp.descriptor.rep2.sig,
-        b"zeta\0": inp.gpr.z,
-        b"trfra": inp.gpr.trainfrac,
-        b"speci": " ".join(inp.system.species),   #str (and list str)
-        b"nspe1": " ".join(inp.descriptor.rep1.neighspe),
-        b"nspe2": " ".join(inp.descriptor.rep2.neighspe),
-        b"dfbas": inp.qm.dfbasis
-    }
+    inputs = [
+        (b"averg", inp.system.average),  #Bools
+        (b"spars", inp.descriptor.sparsify.ncut > 0),
+        (b"ncut\0", inp.descriptor.sparsify.ncut),  #int32
+        (b"nang1", inp.descriptor.rep1.nang),
+        (b"nang2", inp.descriptor.rep2.nang),
+        (b"nrad1", inp.descriptor.rep1.nrad),
+        (b"nrad2", inp.descriptor.rep2.nrad),
+        (b"Menv\0", inp.gpr.Menv),
+        (b"Ntran", inp.gpr.Ntrain),
+        (b"rcut1", inp.descriptor.rep1.rcut),  #float64
+        (b"rcut2", inp.descriptor.rep2.rcut),
+        (b"sig1\0", inp.descriptor.rep1.sig),
+        (b"sig2\0", inp.descriptor.rep2.sig),
+        (b"zeta\0", inp.gpr.z),
+        (b"trfra", inp.gpr.trainfrac),
+        (b"speci", " ".join(inp.system.species)),   #str (and list str)
+        (b"nspe1", " ".join(inp.descriptor.rep1.neighspe)),
+        (b"nspe2", " ".join(inp.descriptor.rep2.neighspe)),
+        (b"dfbas", inp.qm.dfbasis)
+    ]
     begin_of_block = SALTED_file.tell()
-    for key in inputs.keys():
-        print(key, inputs[key])
-        if isinstance(inputs[key], bool):
-            SALTED_file.write(key)
-            SALTED_file.write(np.int32(types_dict["bool"]).tobytes())
-            SALTED_file.write(np.bool_(int(inputs[key])).tobytes())
-        elif isinstance(inputs[key], int):
-            SALTED_file.write(key)
-            SALTED_file.write(np.int32(types_dict["int32"]).tobytes())
-            SALTED_file.write(np.int32(inputs[key]).tobytes())
-        elif isinstance(inputs[key], float):
-            SALTED_file.write(key)
-            SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
-            SALTED_file.write(np.float64(inputs[key]).tobytes())
-        elif isinstance(inputs[key], str):
-            SALTED_file.write(key)
-            SALTED_file.write(np.int32(types_dict["str"]).tobytes())
-            SALTED_file.write(np.int32(len(inputs[key])).tobytes())
-            print(inputs[key].encode("utf-8"))
-            SALTED_file.write(inputs[key].encode("utf-8"))
+    for key, value in inputs:
+        print(key, value)
+        write_key5(SALTED_file, key)
+        if isinstance(value, bool):
+            SALTED_file.write(i32(int(types_dict["bool"])))
+            SALTED_file.write(i32(int(value)))
+        elif isinstance(value, int):
+            SALTED_file.write(i32(int(types_dict["int32"])))
+            SALTED_file.write(i32(value))
+        elif isinstance(value, float):
+            SALTED_file.write(i32(int(types_dict["float64"])))
+            SALTED_file.write(f64(value))
+        elif isinstance(value, str):
+            SALTED_file.write(i32(int(types_dict["str"])))
+            enc = value.encode("utf-8")
+            SALTED_file.write(i32(len(enc)))
+            SALTED_file.write(enc)
         else:
-            print(key, inputs[key])
+            print(key, value)
             raise ValueError("Unknown type")
     write_chunk_location(SALTED_file, "CONFG", begin_of_block)
 
@@ -263,12 +280,10 @@ def preprocess_shells(basis):
 #nElements (4 bytes, int32)
 #For each element:
     #Element ID (4 bytes, int32)
-    #nShells (4 bytes, int32)
-    #nPrimitives (4 bytes, int32)
-    #contractions_per_shell (nShells*4 bytes, int32)
-    #angular_momenta_per_shell (nShells*4 bytes, int32)
-    #exponents_per_shell (nPrimitives*8 bytes, float64)
-    #coeffs_per_shell (nPrimitives*8 bytes, float64)
+    #FOR EACH ARRAY iN [CONTRACTIONS, ANGULAR MOMENTA, EXPONENTS, COEFFS]:
+        #N_DIMS (4 bytes, int32)
+        #DIMS (nDims*4 bytes, int32)
+        #DATA (dim1*8 bytes, float64)
 def pack_basis(SALTED_file, inp):
     try:
         from pyscf import gto
@@ -284,34 +299,44 @@ def pack_basis(SALTED_file, inp):
     basis = {}
     for symbol in symbols:
         basis[symbol] = gto.basis.load(basis_name, symb=symbol)
-    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())  # Data type
-    SALTED_file.write(np.int32(len(symbols)).tobytes()) # Number of elements (blocks to read after this)
+    SALTED_file.write(i32(int(types_dict["float64"])))  # Data type
+    SALTED_file.write(i32(int(len(symbols)))) # Number of elements (blocks to read after this)
     for elem in symbols:
-        SALTED_file.write(np.int32(ELEMENTS_TO_NUM[elem]).tobytes())
+        SALTED_file.write(i32(int(ELEMENTS_TO_NUM[elem])))
         shells = basis[elem]
         (contractions_per_shell,
          angular_momenta_per_shell,
          coeffs_per_shell,
          exponents_per_shell) = preprocess_shells(shells)
-        SALTED_file.write(np.int32(len(shells)).tobytes())  # Number of shells
-        SALTED_file.write(np.int32(len(coeffs_per_shell)).tobytes())  # Number of primitives
-        SALTED_file.write(np.array(contractions_per_shell, dtype=np.int32).tobytes())
-        SALTED_file.write(np.array(angular_momenta_per_shell, dtype=np.int32).tobytes())
-        SALTED_file.write(np.array(exponents_per_shell, dtype=np.float64).tobytes())
-        SALTED_file.write(np.array(coeffs_per_shell, dtype=np.float64).tobytes())
-    
+        write_data_head(SALTED_file, np.array(contractions_per_shell))
+        SALTED_file.write(np.array(contractions_per_shell, dtype="<i4").tobytes())
+        write_data_head(SALTED_file, np.array(angular_momenta_per_shell))
+        SALTED_file.write(np.array(angular_momenta_per_shell, dtype="<i4").tobytes())
+        write_data_head(SALTED_file, np.array(exponents_per_shell))
+        SALTED_file.write(np.array(exponents_per_shell, dtype="<f8").tobytes())
+        write_data_head(SALTED_file, np.array(coeffs_per_shell))
+        SALTED_file.write(np.array(coeffs_per_shell, dtype="<f8").tobytes())
+
     write_chunk_location(SALTED_file, "BASIS", begin_of_block)
 
 MAGIC_NUMBER = b"SALTD"  # 5-byte identifier
-VERSION = np.int32(2)
-BLOCKS = ["AVERG", "WIG", "FPS", "DESCR", "PROJE", "WEIGH", "CONF", "BASIS"]
-N_BLOCKS = np.int32(len(BLOCKS))
+VERSION = 2
+HAS_PYSCF = False
+try:
+    import pyscf
+    HAS_PYSCF = True
+except ImportError:
+    HAS_PYSCF = False
+
+BLOCKS = ["AVERG", "WIG", "FPS", "FEATS", "PROJE", "WEIGH", "CONFG"]
+if HAS_PYSCF: BLOCKS.append("BASIS")
+N_BLOCKS = len(BLOCKS)
 def write_header(SALTED_file):
     SALTED_file.write(MAGIC_NUMBER)
-    SALTED_file.write(VERSION.tobytes())
-    SALTED_file.write(N_BLOCKS.tobytes())
-    #Leave (5*4)*N_Blocks bytes for the block names and locations (5bytes for the name, 4 bytes for the location)
-    SALTED_file.write(b'\0'*(5*4)*N_BLOCKS)
+    SALTED_file.write(i32(int(VERSION)))
+    SALTED_file.write(i32(N_BLOCKS))
+    #Leave (5+4)*N_Blocks bytes for the block names and locations (5bytes for the name, 4 bytes for the location)
+    SALTED_file.write(b'\0'*(5+4)*N_BLOCKS)
     
 def build():
     inp = ParseConfig().parse_input()
@@ -325,7 +350,8 @@ def build():
         pack_FEATS(f, path, inp)
         pack_projectors(f, path, inp)
         pack_weights(f, path, inp)
-        pack_basis(f, inp)
+        if HAS_PYSCF:
+            pack_basis(f, inp)
 
 if __name__ == "__main__":
     build()

--- a/salted/pack_model.py
+++ b/salted/pack_model.py
@@ -8,6 +8,7 @@ def u32(x):  return struct.pack('<I', x)
 def i32(x):  return struct.pack('<i', x)
 def i64(x):  return struct.pack('<q', x)
 def f64(x):  return struct.pack('<d', x)
+def sbool(x): return struct.pack('<?', x)
 
 from salted.sys_utils import ParseConfig
 #EVERYTHING IS LITTLE ENDIAN!
@@ -242,7 +243,7 @@ def pack_model_info(SALTED_file, inp):
         write_key5(SALTED_file, key)
         if isinstance(value, bool):
             SALTED_file.write(i32(int(types_dict["bool"])))
-            SALTED_file.write(i32(int(value)))
+            SALTED_file.write(sbool(int(value)))
         elif isinstance(value, int):
             SALTED_file.write(i32(int(types_dict["int32"])))
             SALTED_file.write(i32(value))

--- a/salted/pack_model.py
+++ b/salted/pack_model.py
@@ -171,7 +171,7 @@ def pack_projectors(SALTED_file, path, inp):
     write_chunk_location(SALTED_file, "PROJE", begin_of_block)
 
 def pack_FEATS(SALTED_file, path, inp):
-    file_feat = first_match(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}_*.h5'))
+    file_feat = first_match(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}*.h5'))
     if file_feat is None:
         raise FileNotFoundError(f"No FEAT file found for M={inp.gpr.Menv} in {os.path.join(path, f'equirepr_{inp.salted.saltedname}')}")
     begin_of_block = SALTED_file.tell()

--- a/salted/pack_model.py
+++ b/salted/pack_model.py
@@ -169,7 +169,7 @@ def pack_projectors(SALTED_file, path, inp):
                 write_data_head(SALTED_file, data)
                 SALTED_file.write(np.asarray(data,dtype='<f8').tobytes())
             print()
-    write_chunk_location(SALTED_file, "PROJE", begin_of_block)
+    write_chunk_location(SALTED_file, "PROJ", begin_of_block)
 
 def pack_FEATS(SALTED_file, path, inp):
     file_feat = first_match(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}*.h5'))
@@ -218,6 +218,7 @@ def pack_weights(SALTED_file, path, inp):
 def pack_model_info(SALTED_file, inp):
     inputs = [
         (b"averg", inp.system.average),  #Bools
+	(b"field", False),
         (b"spars", inp.descriptor.sparsify.ncut > 0),
         (b"ncut\0", inp.descriptor.sparsify.ncut),  #int32
         (b"nang1", inp.descriptor.rep1.nang),
@@ -329,7 +330,7 @@ try:
 except ImportError:
     HAS_PYSCF = False
 
-BLOCKS = ["AVERG", "WIG", "FPS", "FEATS", "PROJE", "WEIGH", "CONFG"]
+BLOCKS = ["AVERG", "WIG", "FPS", "FEATS", "PROJ", "WEIGH", "CONFG"]
 if HAS_PYSCF: BLOCKS.append("BASIS")
 N_BLOCKS = len(BLOCKS)
 def write_header(SALTED_file):

--- a/salted/pack_model.py
+++ b/salted/pack_model.py
@@ -1,0 +1,331 @@
+import h5py
+import glob, os
+import numpy as np
+
+from salted.sys_utils import ParseConfig
+#FORMAT FOR SALTED FILE:
+#MAGIC_NUMBER (5 bytes, str)
+#VERSION (4 bytes, int32)
+#N_BLOCKS (4 bytes, int32)
+#FOR EACH BLOCK:
+    #BLOCK_NAME (5 bytes, str)
+    #BLOCK_LOCATION (4 bytes, int32)
+#DATA (variable size)
+
+#FORMAT FOR DATA: (Slightly depending on Context)
+#TYPE_OF_DATA (4 bytes, int32)
+#nfiles (4 bytes, int32) #If multiple files
+#FOR EACH FILE:
+    #ndims (4 bytes, int32)
+    #dims (4*ndims bytes, int32)
+    #data (ndims*8 bytes, float64)
+
+
+types_dict = {
+    "int32": 0,
+    "int64": 1,
+    "float32": 2,
+    "float64": 3,
+    "str": 4,
+    "bool": 5,
+}
+OFFSET_TABLE_OF_CONTENTS = 5+4+4
+
+
+def write_data_head(SALTED_file, data):
+    SALTED_file.write(np.int32(data.ndim))
+    for dim in data.shape:
+        SALTED_file.write(np.int32(dim))
+
+
+
+def write_chunk_location(SALTED_file, chunk_name, location):
+    global OFFSET_TABLE_OF_CONTENTS
+    end_of_block = SALTED_file.tell()
+    SALTED_file.seek(OFFSET_TABLE_OF_CONTENTS)
+    SALTED_file.write(chunk_name.encode("utf-8"))
+    SALTED_file.write(b'\0'*(5-len(chunk_name)))
+    SALTED_file.write(np.int32(location).tobytes())
+    SALTED_file.seek(end_of_block)
+    OFFSET_TABLE_OF_CONTENTS += 5+4
+
+
+
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#nfiles (4 bytes, int32)
+#FOR EACH FILE:
+    #element (5 bytes, str)
+    #ndims (4 bytes, int32)
+    #dims (4*ndims bytes, int32)
+    #data (ndims*8 bytes, float64)
+def pack_averages(SALTED_file, path):
+    print("Writing Averages")
+    begin_of_block = SALTED_file.tell()
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    files = glob.glob(os.path.join(path,"averages",'av*.npy'))
+    SALTED_file.write(np.int32(len(files)).tobytes())
+    for file in files:
+        element = os.path.basename(file).split('.')[0].split("_")[-1]
+        SALTED_file.write(element.encode("utf-8"))
+        SALTED_file.write(b'\0'*(5-len(element)))
+        data = np.load(file).astype(np.float64)
+        write_data_head(SALTED_file, data)
+        SALTED_file.write(data.tobytes())
+    write_chunk_location(SALTED_file, "AVERG", begin_of_block)
+        
+
+#HAS TO BE IN INCREASING ORDER
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#nfiles (4 bytes, int32)
+#FOR EACH FILE:
+    #ndims (4 bytes, int32)
+    #dims (4*ndims bytes, int32)
+    #data (ndims*8 bytes, float64)
+def pack_wigners(SALTED_file, path, inp):
+    print("Writing Wigners")
+    begin_of_block = SALTED_file.tell()
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    files = glob.glob(os.path.join(path,"wigners",f'wigner_lam-*_lmax1-{inp.descriptor.rep1.nang}_lmax2-{inp.descriptor.rep2.nang}.dat'))
+    files.sort(key=lambda x: int(x.split("_")[1].split("-")[1]))
+    SALTED_file.write(np.int32(len(files)).tobytes())
+    for file in files:
+        print(file)
+        data = np.loadtxt(file).astype(np.float64)
+        write_data_head(SALTED_file, data)
+        SALTED_file.write(data.tobytes())
+    write_chunk_location(SALTED_file, "WIG", begin_of_block)
+
+
+#LAMDA HAS TO BE IN INCREASING ORDER
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#Nfiles (4 bytes, int32)
+#FOR EACH FILE:
+    #ndims (4 bytes, int32)
+    #dims (4*ndims bytes, int32)
+    #data (ndims*8 bytes, float64)
+def pack_fps(SALTED_file, path, inp):
+    print("Writing FPS")
+    begin_of_block = SALTED_file.tell()
+    SALTED_file.write(np.int32(types_dict["int64"]).tobytes())
+    files = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'fps{inp.descriptor.sparsify.ncut}-*.npy'))
+    files.sort(key=lambda x: int(x.split("-")[-1].split(".")[0]))
+    SALTED_file.write(np.int32(len(files)).tobytes())
+    for file in files:
+        print(file)
+        data = np.load(file).astype(np.int64)
+        write_data_head(SALTED_file, data)
+        SALTED_file.write(data.tobytes())
+    write_chunk_location(SALTED_file, "FPS", begin_of_block)
+
+
+
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#nkeys (4 bytes, int32)
+#atomic_species (5 bytes, str)
+#For each atomic species:
+    #nlambda (4 bytes, int32)
+    #FOR EACH lambda:
+        #ndims (4 bytes, int32)
+        #dims (4*ndims bytes, int32)
+        #data (dim1*dim2*8 bytes, float64)
+def pack_projectors(SALTED_file, path, inp):
+    file_proj = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'projector_M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}.h5'))[0]
+    begin_of_block = SALTED_file.tell()
+    print(f"Reading {file_proj}")
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    with h5py.File(file_proj, 'r') as h5file:
+        SALTED_file.write(np.int32(len(h5file["projectors"].keys())).tobytes())
+        for key in list(h5file["projectors"].keys()):
+            print(key, end=": ")
+            #First 5 bytes are the key as string
+            SALTED_file.write(key.encode("utf-8"))
+            SALTED_file.write(b'\0'*(5-len(key)))
+            #Write the number of sub-keys
+            SALTED_file.write(np.int32(len(h5file["projectors"][key].keys())).tobytes())
+            for key2 in h5file["projectors"][key].keys():
+                print(key2, end = " ")
+                data = np.array(h5file["projectors"][key][key2], dtype=np.float64)
+                write_data_head(SALTED_file, data)
+                SALTED_file.write(data.tobytes())
+            print()
+    write_chunk_location(SALTED_file, "PROJ", begin_of_block)
+
+def pack_FEATS(SALTED_file, path, inp):
+    file_feat = glob.glob(os.path.join(path, f"equirepr_{inp.salted.saltedname}", f'FEAT_M-{inp.gpr.Menv}.h5'))[0]
+    begin_of_block = SALTED_file.tell()
+    print(f"Reading {file_feat}")
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    with h5py.File(file_feat, 'r') as h5file:
+        SALTED_file.write(np.int32(len(h5file["sparse_descriptors"].keys())).tobytes())
+        for key in list(h5file["sparse_descriptors"].keys()):
+            print(key, end=": ")
+            #First 5 bytes are the key as string
+            SALTED_file.write(key.encode("utf-8"))
+            SALTED_file.write(b'\0'*(5-len(key)))
+            #Write the number of sub-keys
+            SALTED_file.write(np.int32(len(h5file["sparse_descriptors"][key].keys())).tobytes())
+            for key2 in h5file["sparse_descriptors"][key].keys():
+                print(key2, end = " ")
+                data = np.array(h5file["sparse_descriptors"][key][key2], dtype=np.float64)
+                write_data_head(SALTED_file, data)
+                SALTED_file.write(data.tobytes())
+            print()
+    write_chunk_location(SALTED_file, "FEATS", begin_of_block)
+
+
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#Nfiles (4 bytes, int32) Here 1
+#FOR EACH FILE:
+    #ndims (4 bytes, int32)
+    #dims (4*ndims bytes, int32)
+    #data (ndims*8 bytes, float64)
+def pack_weights(SALTED_file, path, inp):
+    begin_of_block = SALTED_file.tell()
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+    SALTED_file.write(np.int32(1).tobytes())
+    file = glob.glob(os.path.join(path, f"regrdir_{inp.salted.saltedname}", f"M{inp.gpr.Menv}_zeta{inp.gpr.z:.1f}", f'weights_N{int(inp.gpr.Ntrain*inp.gpr.trainfrac)}_reg*'))[0]
+    data = np.load(file).astype(np.float64)
+    write_data_head(SALTED_file, data)
+    SALTED_file.write(data.tobytes())
+    write_chunk_location(SALTED_file, "WEIGH", begin_of_block)
+
+def pack_model_info(SALTED_file, inp):
+    inputs = {
+        b"averg": inp.system.average,  #Bools
+        b"spars": inp.descriptor.sparsify.ncut > 0,
+        b"ncut\0": inp.descriptor.sparsify.ncut,  #int32
+        b"nang1": inp.descriptor.rep1.nang,
+        b"nang2": inp.descriptor.rep2.nang,
+        b"nrad1": inp.descriptor.rep1.nrad,
+        b"nrad2": inp.descriptor.rep2.nrad,
+        b"Menv\0": inp.gpr.Menv,
+        b"Ntran": inp.gpr.Ntrain,
+        b"rcut1": inp.descriptor.rep1.rcut,  #float64
+        b"rcut2": inp.descriptor.rep2.rcut,
+        b"sig1\0": inp.descriptor.rep1.sig,
+        b"sig2\0": inp.descriptor.rep2.sig,
+        b"zeta\0": inp.gpr.z,
+        b"trfra": inp.gpr.trainfrac,
+        b"speci": " ".join(inp.system.species),   #str (and list str)
+        b"nspe1": " ".join(inp.descriptor.rep1.neighspe),
+        b"nspe2": " ".join(inp.descriptor.rep2.neighspe),
+        b"dfbas": inp.qm.dfbasis
+    }
+    begin_of_block = SALTED_file.tell()
+    for key in inputs.keys():
+        print(key, inputs[key])
+        if isinstance(inputs[key], bool):
+            SALTED_file.write(key)
+            SALTED_file.write(np.int32(types_dict["bool"]).tobytes())
+            SALTED_file.write(np.bool_(int(inputs[key])).tobytes())
+        elif isinstance(inputs[key], int):
+            SALTED_file.write(key)
+            SALTED_file.write(np.int32(types_dict["int32"]).tobytes())
+            SALTED_file.write(np.int32(inputs[key]).tobytes())
+        elif isinstance(inputs[key], float):
+            SALTED_file.write(key)
+            SALTED_file.write(np.int32(types_dict["float64"]).tobytes())
+            SALTED_file.write(np.float64(inputs[key]).tobytes())
+        elif isinstance(inputs[key], str):
+            SALTED_file.write(key)
+            SALTED_file.write(np.int32(types_dict["str"]).tobytes())
+            SALTED_file.write(np.int32(len(inputs[key])).tobytes())
+            print(inputs[key].encode("utf-8"))
+            SALTED_file.write(inputs[key].encode("utf-8"))
+        else:
+            print(key, inputs[key])
+            raise ValueError("Unknown type")
+    write_chunk_location(SALTED_file, "CONFG", begin_of_block)
+
+
+def preprocess_shells(basis):
+    contractions_per_shell = []
+    angular_momenta_per_shell = []
+    coeffs_per_shell = []
+    exponents_per_shell = []
+    for shell in basis:
+        angular_momenta_per_shell.append(shell[0])
+        contractions_per_shell.append(len(shell) - 1)
+        for exp,coef in shell[1:]:
+            exponents_per_shell.append(exp)
+            coeffs_per_shell.append(coef)
+    return (contractions_per_shell, angular_momenta_per_shell,
+            coeffs_per_shell, exponents_per_shell)
+
+
+#Format:
+#TYPE_OF_DATA (4 bytes, int32)
+#nElements (4 bytes, int32)
+#For each element:
+    #Element ID (4 bytes, int32)
+    #nShells (4 bytes, int32)
+    #nPrimitives (4 bytes, int32)
+    #contractions_per_shell (nShells*4 bytes, int32)
+    #angular_momenta_per_shell (nShells*4 bytes, int32)
+    #exponents_per_shell (nPrimitives*8 bytes, float64)
+    #coeffs_per_shell (nPrimitives*8 bytes, float64)
+def pack_basis(SALTED_file, inp):
+    try:
+        from pyscf import gto
+        from pyscf.data.elements import ELEMENTS
+        ELEMENTS_TO_NUM = {x: i for i,x in enumerate(ELEMENTS)}
+    except ImportError:
+        print("PySCF not found, cannot include basis sets in SALTED file, skipping basis packing")
+        return
+    
+    begin_of_block = SALTED_file.tell()
+    basis_name = inp.qm.dfbasis
+    symbols = inp.system.species
+    basis = {}
+    for symbol in symbols:
+        basis[symbol] = gto.basis.load(basis_name, symb=symbol)
+    SALTED_file.write(np.int32(types_dict["float64"]).tobytes())  # Data type
+    SALTED_file.write(np.int32(len(symbols)).tobytes()) # Number of elements (blocks to read after this)
+    for elem in symbols:
+        SALTED_file.write(np.int32(ELEMENTS_TO_NUM[elem]).tobytes())
+        shells = basis[elem]
+        (contractions_per_shell,
+         angular_momenta_per_shell,
+         coeffs_per_shell,
+         exponents_per_shell) = preprocess_shells(shells)
+        SALTED_file.write(np.int32(len(shells)).tobytes())  # Number of shells
+        SALTED_file.write(np.int32(len(coeffs_per_shell)).tobytes())  # Number of primitives
+        SALTED_file.write(np.array(contractions_per_shell, dtype=np.int32).tobytes())
+        SALTED_file.write(np.array(angular_momenta_per_shell, dtype=np.int32).tobytes())
+        SALTED_file.write(np.array(exponents_per_shell, dtype=np.float64).tobytes())
+        SALTED_file.write(np.array(coeffs_per_shell, dtype=np.float64).tobytes())
+    
+    write_chunk_location(SALTED_file, "BASIS", begin_of_block)
+
+MAGIC_NUMBER = b"SALTD"  # 5-byte identifier
+VERSION = np.int32(2)
+BLOCKS = ["AVERG", "WIG", "FPS", "DESCR", "PROJE", "WEIGH", "CONF", "BASIS"]
+N_BLOCKS = np.int32(len(BLOCKS))
+def write_header(SALTED_file):
+    SALTED_file.write(MAGIC_NUMBER)
+    SALTED_file.write(VERSION.tobytes())
+    SALTED_file.write(N_BLOCKS.tobytes())
+    #Leave (5*4)*N_Blocks bytes for the block names and locations (5bytes for the name, 4 bytes for the location)
+    SALTED_file.write(b'\0'*(5*4)*N_BLOCKS)
+    
+def build():
+    inp = ParseConfig().parse_input()
+    path = inp.salted.saltedpath
+    with open(f"{inp.salted.saltedname}.salted", "wb") as f:
+        write_header(f)
+        pack_model_info(f, inp)
+        pack_averages(f, path)
+        pack_wigners(f, path, inp)
+        pack_fps(f, path, inp)
+        pack_FEATS(f, path, inp)
+        pack_projectors(f, path, inp)
+        pack_weights(f, path, inp)
+        pack_basis(f, inp)
+
+if __name__ == "__main__":
+    build()

--- a/salted/predict_from_model.py
+++ b/salted/predict_from_model.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python
+"""
+Standalone prediction script that uses only a .salted model file and an xyz file
+to predict density expansion coefficients.
+
+Usage:
+    python predict_from_model.py <model.salted> <structures.xyz> [output_dir]
+"""
+
+import os
+import sys
+import time
+import argparse
+import numpy as np
+from typing import Dict, Tuple, List
+from ase.io import read
+from ase.data import atomic_numbers
+
+import read_model
+
+# Import SALTED modules for feature computation
+try:
+    from salted import sph_utils
+    from salted.lib import equicomb, equicombsparse
+    from salted import basis
+except ImportError:
+    print("Error: SALTED package not found. Please install SALTED.")
+    sys.exit(1)
+
+
+def read_system_from_xyz(filename: str, species: List[str], dfbasis: str):
+    """
+    Read geometry file and return formatted system information.
+    
+    Parameters
+    ----------
+    filename : str
+        Path to XYZ file
+    species : list of str
+        List of atomic species to include
+    dfbasis : str
+        Density fitting basis set name
+        
+    Returns
+    -------
+    tuple
+        (species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax)
+    """
+    # Read basis
+    lmax, nmax = basis.basiset(dfbasis)
+    llist = []
+    nlist = []
+    for spe in species:
+        llist.append(lmax[spe])
+        for l in range(lmax[spe] + 1):
+            nlist.append(nmax[(spe, l)])
+    nnmax = max(nlist)
+    lmax_max = max(llist)
+
+    # Read structures
+    frames = read(filename, ":", parallel=False)
+    ndata = len(frames)
+
+    # Extract atomic symbols, filtering by species list
+    atomic_symbols = []
+    natoms = np.zeros(ndata, int)
+    for iconf in range(ndata):
+        symbols = frames[iconf].get_chemical_symbols()
+        # Filter out species not in our list
+        filtered_symbols = [s for s in symbols if s in species]
+        atomic_symbols.append(filtered_symbols)
+        natoms[iconf] = len(filtered_symbols)
+
+    natmax = max(natoms)
+
+    return species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax
+
+
+def get_atom_idx(ndata: int, natoms: np.ndarray, species: List[str], atomic_symbols: List[List[str]]):
+    """Get indices of atoms by species for each configuration."""
+    atom_idx = {}
+    natom_dict = {}
+    
+    for iconf in range(ndata):
+        for spe in species:
+            atom_idx[(iconf, spe)] = []
+            natom_dict[(iconf, spe)] = 0
+    
+    for iconf in range(ndata):
+        for iat in range(natoms[iconf]):
+            spe = atomic_symbols[iconf][iat]
+            atom_idx[(iconf, spe)].append(iat)
+            natom_dict[(iconf, spe)] += 1
+    
+    return atom_idx, natom_dict
+
+
+def compute_predictions(model_file: str, xyz_file: str, output_dir: str = None):
+    """
+    Compute predictions using a SALTED model and XYZ structures.
+    
+    Parameters
+    ----------
+    model_file : str
+        Path to .salted model file
+    xyz_file : str
+        Path to XYZ file with structures
+    output_dir : str, optional
+        Directory for output files (default: current directory)
+    """
+    
+    print(f"Loading model from {model_file}...")
+    model = read_model.read_salted_model(model_file)
+    
+    # Extract configuration from model
+    config = model['config']
+    species_str = config['speci']
+    species = species_str.split()
+    
+    # Extract hyperparameters
+    nang1 = config['nang1']
+    nang2 = config['nang2']
+    nrad1 = config['nrad1']
+    nrad2 = config['nrad2']
+    rcut1 = config['rcut1']
+    rcut2 = config['rcut2']
+    sig1 = config['sig1']
+    sig2 = config['sig2']
+    zeta = config['zeta']
+    use_average = config['averg']
+    use_sparsify = config['spars']
+    ncut = config.get('ncut', 0)
+    dfbasis = config['dfbas']
+    
+    neighspe1_str = config.get('nspe1', species_str)
+    neighspe2_str = config.get('nspe2', species_str)
+    neighspe1 = neighspe1_str.split()
+    neighspe2 = neighspe2_str.split()
+    nspe1 = len(neighspe1)
+    nspe2 = len(neighspe2)
+    
+    # Representation types (density expansion uses "rho")
+    rep1 = "rho"
+    rep2 = "rho"
+    
+    print(f"Model configuration:")
+    print(f"  Species: {species}")
+    print(f"  Basis: {dfbasis}")
+    print(f"  nang1={nang1}, nang2={nang2}, nrad1={nrad1}, nrad2={nrad2}")
+    print(f"  rcut1={rcut1}, rcut2={rcut2}, sig1={sig1}, sig2={sig2}")
+    print(f"  zeta={zeta}, sparsify={use_sparsify}, average={use_average}")
+    
+    # Read system
+    print(f"\nReading structures from {xyz_file}...")
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system_from_xyz(
+        xyz_file, species, dfbasis
+    )
+    print(f"  Found {ndata} structures")
+    print(f"  Max atoms per structure: {natmax}")
+    
+    # Get atom indices
+    atom_idx, natom_dict = get_atom_idx(ndata, natoms, species, atomic_symbols)
+    
+    # Read frames
+    frames = read(xyz_file, ":")
+    
+    # Setup output directory
+    if output_dir is None:
+        output_dir = "predictions"
+    os.makedirs(output_dir, exist_ok=True)
+    print(f"  Output directory: {output_dir}")
+    
+    # Extract model data
+    weights = model['weights']
+    wigners = model['wigners']
+    averages = model.get('averages', {})
+    fps_data = model.get('fps', [])
+    feats = model['feats']
+    projectors = model['projectors']
+    
+    # Compute features
+    print("\nComputing atomic representations...")
+    start_time = time.time()
+    
+    # Setup hyperparameters for density representation
+    HYPER_PARAMETERS_DENSITY = {
+        "cutoff": {
+            "radius": rcut1,
+            "smoothing": {
+                "type": "ShiftedCosine",
+                "width": 0.1
+            }
+        },
+        "density": {
+            "type": "Gaussian",
+            "width": sig1
+        },
+        "basis": {
+            "type": "TensorProduct",
+            "max_angular": nang1,
+            "radial": {
+                "type": "Gto",
+                "max_radial": nrad1 - 1
+            },
+            "spline_accuracy": 1e-06
+        }
+    }
+    
+    HYPER_PARAMETERS_POTENTIAL = {
+        "density": {
+            "type": "SmearedPowerLaw",
+            "smearing": sig2,
+            "exponent": 1
+        },
+        "basis": {
+            "type": "TensorProduct",
+            "max_angular": nang2,
+            "radial": {
+                "type": "Gto",
+                "max_radial": nrad2 - 1,
+                "radius": rcut2
+            },
+            "spline_accuracy": 1e-06
+        }
+    }
+    
+    natoms_total = sum(natoms)
+    
+    # Compute SOAP-like representations
+    omega1 = sph_utils.get_representation_coeffs(
+        frames, rep1, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL,
+        0, neighspe1, species, nang1, nrad1, natoms_total
+    )
+    omega2 = sph_utils.get_representation_coeffs(
+        frames, rep2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL,
+        0, neighspe2, species, nang2, nrad2, natoms_total
+    )
+    
+    # Reshape for Fortran indexing
+    v1 = np.transpose(omega1, (2, 0, 3, 1))
+    v2 = np.transpose(omega2, (2, 0, 3, 1))
+    
+    print(f"  Feature computation time: {time.time() - start_time:.2f} s")
+    
+    # Prepare FPS indices if using sparsification
+    vfps = {}
+    if use_sparsify:
+        for lam in range(lmax_max + 1):
+            if lam < len(fps_data):
+                vfps[lam] = fps_data[lam]
+            else:
+                print(f"Warning: FPS data missing for lambda={lam}")
+    
+    # Load projectors and features into dictionaries
+    Vmat = {}
+    power_env_sparse = {}
+    Mspe = {}
+    
+    for spe in species:
+        if spe not in feats or spe not in projectors:
+            print(f"Warning: Missing data for species {spe}")
+            continue
+            
+        for lam in range(lmax[spe] + 1):
+            lam_str = str(lam)
+            if lam_str in feats[spe]:
+                power_env_sparse[(lam, spe)] = feats[spe][lam_str]
+            if lam_str in projectors[spe]:
+                Vmat[(lam, spe)] = projectors[spe][lam_str]
+            
+            if lam == 0:
+                Mspe[spe] = power_env_sparse[(lam, spe)].shape[0]
+            
+            # Precompute projection if linear (zeta=1)
+            if zeta == 1 and (lam, spe) in power_env_sparse and (lam, spe) in Vmat:
+                power_env_sparse[(lam, spe)] = np.dot(
+                    Vmat[(lam, spe)].T, power_env_sparse[(lam, spe)]
+                )
+    
+    # Compute predictions for each structure
+    print(f"\nComputing predictions for {ndata} structures...")
+    
+    # First compute all equivariant descriptors for all atoms at once
+    print("  Computing equivariant descriptors...")
+    pvec = {}
+    
+    for lam in range(lmax_max + 1):
+        # Get angular indices
+        llmax, llvec = sph_utils.get_angular_indexes_symmetric(lam, nang1, nang2)
+        
+        # Get Wigner symbols
+        if lam < len(wigners):
+            wigner3j = wigners[lam]
+        else:
+            print(f"Warning: Missing Wigner data for lambda={lam}")
+            continue
+        
+        wigdim = wigner3j.size
+        
+        # Complex to real transformation
+        c2r = sph_utils.complex_to_real_transformation([2*lam + 1])[0]
+        
+        # Compute combined features for ALL atoms
+        if use_sparsify and lam in vfps:
+            featsize = nspe1 * nspe2 * nrad1 * nrad2 * llmax
+            nfps = len(vfps[lam])
+            p = equicombsparse.equicombsparse(
+                natoms_total, nang1, nang2, nspe1*nrad1, nspe2*nrad2,
+                v1, v2, wigdim, wigner3j, llmax, llvec.T, lam, c2r,
+                featsize, nfps, vfps[lam]
+            )
+            p = np.transpose(p, (2, 0, 1))
+            featsize = ncut
+        else:
+            featsize = nspe1 * nspe2 * nrad1 * nrad2 * llmax
+            p = equicomb.equicomb(
+                natoms_total, nang1, nang2, nspe1*nrad1, nspe2*nrad2,
+                v1, v2, wigdim, wigner3j, llmax, llvec.T, lam, c2r, featsize
+            )
+            p = np.transpose(p, (2, 0, 1))
+        
+        # Reshape and store
+        if lam == 0:
+            p = p.reshape(natoms_total, featsize)
+            pvec[lam] = np.zeros((ndata, natmax, featsize))
+        else:
+            p = p.reshape(natoms_total, 2*lam + 1, featsize)
+            pvec[lam] = np.zeros((ndata, natmax, 2*lam + 1, featsize))
+        
+        # Distribute to structures
+        j = 0
+        for iconf in range(ndata):
+            for iat in range(natoms[iconf]):
+                pvec[lam][iconf, iat] = p[j]
+                j += 1
+    
+    print("  Equivariant descriptors computed.")
+    
+    # Now compute predictions for each structure
+    for iconf in range(ndata):
+        print(f"  Structure {iconf + 1}/{ndata}...", end=" ", flush=True)
+        start = time.time()
+        
+        # Compute kernel and predictions
+        psi_nm = {}
+        
+        for spe in species:
+            atom_indices = atom_idx[(iconf, spe)]
+            # Lambda = 0
+            if (0, spe) in power_env_sparse:
+                if zeta == 1:
+                    psi_nm[(spe, 0)] = np.dot(
+                        pvec[0][iconf, atom_indices], power_env_sparse[(0, spe)].T
+                    )
+                else:
+                    kernel0_nm = np.dot(
+                        pvec[0][iconf, atom_indices], power_env_sparse[(0, spe)].T
+                    )
+                    kernel_nm = kernel0_nm ** zeta
+                    psi_nm[(spe, 0)] = np.dot(kernel_nm, Vmat[(0, spe)])
+            
+            # Lambda > 0
+            for lam in range(1, lmax[spe] + 1):
+                featsize = pvec[lam].shape[-1]
+                
+                if zeta == 1:
+                    psi_nm[(spe, lam)] = np.dot(
+                        pvec[lam][iconf, atom_indices].reshape(natom_dict[(iconf, spe)] * (2*lam + 1), featsize),
+                        power_env_sparse[(lam, spe)].T
+                    )
+                else:
+                    kernel_nm = np.dot(
+                        pvec[lam][iconf, atom_indices].reshape(natom_dict[(iconf, spe)] * (2*lam + 1), featsize),
+                        power_env_sparse[(lam, spe)].T
+                    )
+                    kernel_nm_blocks = kernel_nm.reshape(
+                        natom_dict[(iconf, spe)], 2*lam + 1, Mspe[spe], 2*lam + 1
+                    )
+                    kernel_nm_blocks *= kernel0_nm[:, np.newaxis, :, np.newaxis] ** (zeta - 1)
+                    kernel_nm = kernel_nm_blocks.reshape(
+                        natom_dict[(iconf, spe)] * (2*lam + 1), Mspe[spe] * (2*lam + 1)
+                    )
+                    psi_nm[(spe, lam)] = np.dot(kernel_nm, Vmat[(lam, spe)])
+        
+        # Compute predictions per channel
+        C = {}
+        ispe = {}
+        isize = 0
+        
+        for spe in species:
+            ispe[spe] = 0
+            for l in range(lmax[spe] + 1):
+                for n in range(nmax[(spe, l)]):
+                    Mcut = psi_nm[(spe, l)].shape[1]
+                    C[(spe, l, n)] = np.dot(psi_nm[(spe, l)], weights[isize:isize + Mcut])
+                    isize += Mcut
+ 
+        # Compute total size needed
+        Tsize = 0
+        for iat in range(natoms[iconf]):
+            spe = atomic_symbols[iconf][iat]
+            for l in range(lmax[spe] + 1):
+                for n in range(nmax[(spe, l)]):
+                    Tsize += 2*l + 1
+        
+        # Fill prediction vector
+        pred_coefs = np.zeros(Tsize)
+        av_coefs = np.zeros(Tsize) if use_average else None
+        
+        i = 0
+        for iat in range(natoms[iconf]):
+            spe = atomic_symbols[iconf][iat]
+            for l in range(lmax[spe] + 1):
+                for n in range(nmax[(spe, l)]):
+                    if (spe, l, n) in C:
+                        pred_coefs[i:i + 2*l + 1] = C[(spe, l, n)][ispe[spe] * (2*l + 1):ispe[spe] * (2*l + 1) + 2*l + 1]
+                    if use_average and l == 0 and av_coefs is not None:
+                        av_coefs[i] = averages[spe][n]
+                    i += 2*l + 1
+            ispe[spe] += 1
+        
+        # Add averages if required
+        if use_average and av_coefs is not None:
+            pred_coefs += av_coefs
+        
+        # Save predictions
+        output_file = os.path.join(output_dir, f"COEFFS-{iconf + 1}.dat")
+        # np.savetxt(output_file, pred_coefs)
+        np.save(output_file.replace('.dat', '.npy'), pred_coefs)
+        
+        print(f"done ({time.time() - start:.2f} s)")
+    
+    print(f"\nPredictions saved to {output_dir}/")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Predict density expansion coefficients using a SALTED model"
+    )
+    parser.add_argument("model", help="Path to .salted model file")
+    parser.add_argument("xyz", help="Path to XYZ structures file")
+    parser.add_argument("-o", "--output", default="predictions", 
+                       help="Output directory (default: predictions)")
+    
+    args = parser.parse_args()
+    
+    if not os.path.exists(args.model):
+        print(f"Error: Model file '{args.model}' not found")
+        sys.exit(1)
+    
+    if not os.path.exists(args.xyz):
+        print(f"Error: XYZ file '{args.xyz}' not found")
+        sys.exit(1)
+    
+    compute_predictions(args.model, args.xyz, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/salted/read_model.py
+++ b/salted/read_model.py
@@ -1,0 +1,410 @@
+import struct
+import numpy as np
+from typing import Dict, List, Tuple, Any, Optional
+
+# Unpacking functions for little-endian format
+def read_u32(f): return struct.unpack('<I', f.read(4))[0]
+def read_i32(f): return struct.unpack('<i', f.read(4))[0]
+def read_i64(f): return struct.unpack('<q', f.read(8))[0]
+def read_f64(f): return struct.unpack('<d', f.read(8))[0]
+def read_bool(f): return struct.unpack('<?', f.read(1))[0]
+
+types_dict = {
+    0: "int32",
+    1: "int64",
+    2: "float32",
+    3: "float64",
+    4: "str",
+    5: "bool",
+}
+
+MAGIC_NUMBER = b"SALTD"
+SUPPORTED_VERSIONS = [2]
+
+def read_key5(f) -> str:
+    """Read a 5-byte key and strip null bytes"""
+    key_bytes = f.read(5)
+    return key_bytes.rstrip(b'\0').decode('utf-8')
+
+def read_data_head(f) -> Tuple[int, Tuple[int, ...]]:
+    """Read the dimensionality and shape of array data"""
+    ndims = read_i32(f)
+    dims = tuple(read_i32(f) for _ in range(ndims))
+    return ndims, dims
+
+def read_header(f) -> Tuple[int, Dict[str, int]]:
+    """Read the file header and return version and block locations"""
+    # Read magic number
+    magic = f.read(5)
+    if magic != MAGIC_NUMBER:
+        raise ValueError(f"Invalid SALTED file: magic number is {magic!r}, expected {MAGIC_NUMBER!r}")
+    
+    # Read version
+    version = read_i32(f)
+    if version not in SUPPORTED_VERSIONS:
+        raise ValueError(f"Unsupported version {version}, supported versions: {SUPPORTED_VERSIONS}")
+    
+    # Read number of blocks
+    n_blocks = read_i32(f)
+    
+    # Read table of contents (block names and locations)
+    blocks = {}
+    for _ in range(n_blocks):
+        block_name = read_key5(f)
+        block_location = read_i32(f)
+        blocks[block_name] = block_location
+    
+    return version, blocks
+
+def read_averages(f) -> Dict[str, np.ndarray]:
+    """Read the AVERG block containing averages for each element"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for averages, got {types_dict[data_type]}")
+    
+    nfiles = read_i32(f)
+    averages = {}
+    
+    for _ in range(nfiles):
+        element = read_key5(f)
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 8
+        data = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+        averages[element] = data
+    
+    return averages
+
+def read_wigners(f) -> List[np.ndarray]:
+    """Read the WIG block containing Wigner matrices"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for wigners, got {types_dict[data_type]}")
+    
+    nfiles = read_i32(f)
+    wigners = []
+    
+    for _ in range(nfiles):
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 8
+        data = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+        wigners.append(data)
+    
+    return wigners
+
+def read_fps(f) -> List[np.ndarray]:
+    """Read the FPS block containing FPS indices"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "int64":
+        raise ValueError(f"Expected int64 data type for FPS, got {types_dict[data_type]}")
+    
+    nfiles = read_i32(f)
+    fps_data = []
+    
+    for _ in range(nfiles):
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 8
+        data = np.frombuffer(f.read(nbytes), dtype='<i8').reshape(dims)
+        fps_data.append(data)
+    
+    return fps_data
+
+def read_projectors(f) -> Dict[str, Dict[str, np.ndarray]]:
+    """Read the PROJE block containing projectors"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for projectors, got {types_dict[data_type]}")
+    
+    nkeys = read_i32(f)
+    projectors = {}
+    
+    for _ in range(nkeys):
+        species = read_key5(f)
+        nlambda = read_i32(f)
+        projectors[species] = {}
+        
+        for _ in range(nlambda):
+            ndims, dims = read_data_head(f)
+            nbytes = np.prod(dims) * 8
+            data = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+            # Use the lambda index as key (0, 1, 2, ...)
+            lambda_idx = len(projectors[species])
+            projectors[species][str(lambda_idx)] = data
+    
+    return projectors
+
+def read_feats(f) -> Dict[str, Dict[str, np.ndarray]]:
+    """Read the FEATS block containing sparse descriptors"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for FEATS, got {types_dict[data_type]}")
+    
+    nkeys = read_i32(f)
+    feats = {}
+    
+    for _ in range(nkeys):
+        species = read_key5(f)
+        nlambda = read_i32(f)
+        feats[species] = {}
+        
+        for _ in range(nlambda):
+            ndims, dims = read_data_head(f)
+            nbytes = np.prod(dims) * 8
+            data = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+            # Use the lambda index as key (0, 1, 2, ...)
+            lambda_idx = len(feats[species])
+            feats[species][str(lambda_idx)] = data
+    
+    return feats
+
+def read_weights(f) -> np.ndarray:
+    """Read the WEIGH block containing regression weights"""
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for weights, got {types_dict[data_type]}")
+    
+    nfiles = read_i32(f)
+    if nfiles != 1:
+        raise ValueError(f"Expected 1 weights file, got {nfiles}")
+    
+    ndims, dims = read_data_head(f)
+    nbytes = np.prod(dims) * 8
+    weights = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+    
+    return weights
+
+def read_config(f) -> Dict[str, Any]:
+    """Read the CONFG block containing model configuration"""
+    config = {}
+    
+    # Read until we hit the end of the block or another block marker
+    # We need to read carefully since we don't know the block size
+    start_pos = f.tell()
+    
+    try:
+        while True:
+            # Try to read a key
+            pos_before = f.tell()
+            key = read_key5(f)
+            
+            # Check if this might be a block marker (next block)
+            # If we can't read a valid type, we've reached the end
+            try:
+                value_type = read_i32(f)
+            except struct.error:
+                f.seek(pos_before)
+                break
+            
+            if value_type not in types_dict:
+                # This is probably the start of the next block
+                f.seek(pos_before)
+                break
+            
+            type_name = types_dict[value_type]
+            
+            if type_name == "bool":
+                value = bool(read_bool(f))
+            elif type_name == "int32":
+                value = read_i32(f)
+            elif type_name == "float64":
+                value = read_f64(f)
+            elif type_name == "str":
+                str_len = read_i32(f)
+                value = f.read(str_len).decode('utf-8')
+            else:
+                raise ValueError(f"Unexpected type in config: {type_name}")
+            
+            config[key] = value
+    except Exception as e:
+        # If we encounter an error, we might be at the end
+        pass
+    
+    return config
+
+def read_basis(f) -> Dict[str, Dict[str, np.ndarray]]:
+    """Read the BASIS block containing basis set information"""
+    try:
+        from pyscf.data.elements import ELEMENTS
+    except ImportError:
+        print("Warning: PySCF not found, element names won't be resolved")
+        ELEMENTS = None
+    
+    data_type = read_i32(f)
+    if types_dict[data_type] != "float64":
+        raise ValueError(f"Expected float64 data type for basis, got {types_dict[data_type]}")
+    
+    n_elements = read_i32(f)
+    basis = {}
+    
+    for _ in range(n_elements):
+        element_num = read_i32(f)
+        if ELEMENTS is not None and element_num < len(ELEMENTS):
+            element_symbol = ELEMENTS[element_num]
+        else:
+            element_symbol = f"Element_{element_num}"
+        
+        basis[element_symbol] = {}
+        
+        # Read contractions per shell
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 4
+        basis[element_symbol]['contractions'] = np.frombuffer(f.read(nbytes), dtype='<i4').reshape(dims)
+        
+        # Read angular momenta per shell
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 4
+        basis[element_symbol]['angular_momenta'] = np.frombuffer(f.read(nbytes), dtype='<i4').reshape(dims)
+        
+        # Read exponents
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 8
+        basis[element_symbol]['exponents'] = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+        
+        # Read coefficients
+        ndims, dims = read_data_head(f)
+        nbytes = np.prod(dims) * 8
+        basis[element_symbol]['coefficients'] = np.frombuffer(f.read(nbytes), dtype='<f8').reshape(dims)
+    
+    return basis
+
+def read_salted_model(filename: str) -> Dict[str, Any]:
+    """
+    Read a SALTED model file and return all its contents.
+    
+    Parameters
+    ----------
+    filename : str
+        Path to the .salted file
+    
+    Returns
+    -------
+    model : dict
+        Dictionary containing all model data with keys:
+        - 'version': File format version
+        - 'config': Model configuration parameters
+        - 'averages': Average values per element
+        - 'wigners': Wigner matrices
+        - 'fps': FPS indices
+        - 'feats': Sparse descriptors
+        - 'projectors': Projector matrices
+        - 'weights': Regression weights
+        - 'basis': Basis set information (if available)
+    """
+    model = {}
+    
+    with open(filename, 'rb') as f:
+        # Read header and get block locations
+        version, blocks = read_header(f)
+        model['version'] = version
+        
+        print(f"SALTED model version {version}")
+        print(f"Available blocks: {list(blocks.keys())}")
+        
+        # Read each block
+        if 'CONFG' in blocks:
+            print("Reading configuration...")
+            f.seek(blocks['CONFG'])
+            model['config'] = read_config(f)
+        
+        if 'AVERG' in blocks:
+            print("Reading averages...")
+            f.seek(blocks['AVERG'])
+            model['averages'] = read_averages(f)
+        
+        if 'WIG' in blocks:
+            print("Reading Wigner matrices...")
+            f.seek(blocks['WIG'])
+            model['wigners'] = read_wigners(f)
+        
+        if 'FPS' in blocks:
+            print("Reading FPS indices...")
+            f.seek(blocks['FPS'])
+            model['fps'] = read_fps(f)
+        
+        if 'FEATS' in blocks:
+            print("Reading sparse descriptors...")
+            f.seek(blocks['FEATS'])
+            model['feats'] = read_feats(f)
+        
+        if 'PROJ' in blocks:
+            print("Reading projectors...")
+            f.seek(blocks['PROJ'])
+            model['projectors'] = read_projectors(f)
+        
+        if 'WEIGH' in blocks:
+            print("Reading weights...")
+            f.seek(blocks['WEIGH'])
+            model['weights'] = read_weights(f)
+        
+        if 'BASIS' in blocks:
+            print("Reading basis sets...")
+            f.seek(blocks['BASIS'])
+            model['basis'] = read_basis(f)
+    
+    return model
+
+def print_model_summary(model: Dict[str, Any]):
+    """Print a summary of the loaded model"""
+    print("\n" + "="*60)
+    print("SALTED Model Summary")
+    print("="*60)
+    
+    print(f"\nVersion: {model.get('version', 'N/A')}")
+    
+    if 'config' in model:
+        print("\nConfiguration:")
+        for key, value in sorted(model['config'].items()):
+            print(f"  {key}: {value}")
+    
+    if 'averages' in model:
+        print(f"\nAverages: {len(model['averages'])} elements")
+        for elem, data in model['averages'].items():
+            print(f"  {elem}: shape {data.shape}")
+    
+    if 'wigners' in model:
+        print(f"\nWigner matrices: {len(model['wigners'])} lambdas")
+        for i, w in enumerate(model['wigners']):
+            print(f"  Lambda {i}: shape {w.shape}")
+    
+    if 'fps' in model:
+        print(f"\nFPS indices: {len(model['fps'])} arrays")
+        for i, fps in enumerate(model['fps']):
+            print(f"  Array {i}: shape {fps.shape}")
+    
+    if 'feats' in model:
+        print(f"\nSparse descriptors: {len(model['feats'])} species")
+        for species, lambdas in model['feats'].items():
+            print(f"  {species}: {len(lambdas)} lambdas")
+    
+    if 'projectors' in model:
+        print(f"\nProjectors: {len(model['projectors'])} species")
+        for species, lambdas in model['projectors'].items():
+            print(f"  {species}: {len(lambdas)} lambdas")
+    
+    if 'weights' in model:
+        print(f"\nWeights: shape {model['weights'].shape}")
+    
+    if 'basis' in model:
+        print(f"\nBasis sets: {len(model['basis'])} elements")
+        for elem in model['basis'].keys():
+            print(f"  {elem}")
+    
+    print("="*60)
+
+if __name__ == "__main__":
+    import sys
+    
+    if len(sys.argv) < 2:
+        print("Usage: python read_model.py <model_file.salted>")
+        sys.exit(1)
+    
+    filename = sys.argv[1]
+    print(f"Reading SALTED model from {filename}...")
+    
+    try:
+        model = read_salted_model(filename)
+        print_model_summary(model)
+    except Exception as e:
+        print(f"Error reading model: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
Adding a short script to write all files neccecary to This PR introduces a new standalone script, salted_pack.py, responsible for building SALTED binary container files from intermediate data produced by the SALTED pipeline. It consolidates and serializes multiple data sources (NumPy arrays, HDF5 datasets, and model parameters) into a single portable binary file for efficient downstream use (e.g., model deployment, reconstruction, or verification).

All integers are little-endian signed 32-bit unless noted; all floating arrays are little-endian float64. All 5-char names are ASCII padded with NUL to 5 bytes.

### General Arrays
In the following every array is encoded using the same scheme:
```
def encode_array(NDIMS:int, DIMS:list[int], data):
  file.write(NDIMS)
  for dim_size in DIMS:
    file.write(dim_size)
  file.write(data)
```
This results in a datastructure as follows:
- NDIMS (int32)
- DIMS (int32 * NDIMS)
- DATA (TYPE OF ARRAY)

The Type of the given array is encoded using the numbers from 0 - 5:
- int32=0
- int64=1
- float32=2
- float64=3
- str=4
- bool=5

Now the different sections of the file are explained in more detail:
### Container header
- MAGIC (5 bytes): b"SALTD"
- VERSION (int32)
- N_BLOCKS (int32)
- TOC: N_BLOCKS entries of:
  - BLOCK_NAME (5 bytes, NUL-padded)
  - BLOCK_OFFSET (int32): file offset (from start) where the block payload begins

### AVERG, WIG, FPS, WEIGH
- TYPE (int32) (datatype of the following block)
- NFILES (int32) (number of arrays in the specific key)
- FOR EACH FILE
  - `encode_array(NDIMS, DIMS, data)`

### FEATS, PROJE
- TYPE (int32): float64
- NKEYS (int32) — top-level HDF5 group count (sorted)
- For each top-level key:
  - KEY5 (5 bytes, NUL-padded)
  - NSUB (int32) — number of datasets under this key (sorted)
  - For each sub-key dataset:
    -  `encode_array(NDIMS, DIMS, data)`

### CONFG
- For each entry in inputs (fixed order in code):
  - KEY5 (5 bytes) — e.g., b"averg", b"ncut\0", …
  - TYPE (int32)
  - VALUE encoded by VAL_TYPE:
    - bool: int32 (0 or 1)
    - int32: int32
    - float64: float64
    - str: SLEN (int32, byte length), then SLEN bytes UTF-8

### BASIS (Only if pyscf is installed)
- TYPE (int32): float64 (tag for numeric arrays in this block)
- NELEM (int32): number of elements included
- For each element:
  - ELEM_ID (int32): PySCF element index
  - Four arrays follow, each preceded by a shape header:
    - contractions_per_shell (int32[])
       -  `encode_array(NDIMS, DIMS, data)`
    - angular_momenta_per_shell (int32[])
      -  `encode_array(NDIMS, DIMS, data)`
    - exponents_per_shell (float64[])
      -  `encode_array(NDIMS, DIMS, data)`
    - coeffs_per_shell (float64[])
      -  `encode_array(NDIMS, DIMS, data)`