### PR TITLE
Fix rep1/2 hyperparameter mapping and remove duplicate representation computation

### DIFF
--- a/salted/cp2k/df2cube.py
+++ b/salted/cp2k/df2cube.py
@@ -29,7 +29,7 @@ def build(structure,coefs,cubename,refcube,comm,size,rank):
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     comm, size, rank, parallel = detect_mpi()
 

--- a/salted/cp2k/polarizability.py
+++ b/salted/cp2k/polarizability.py
@@ -23,7 +23,7 @@ def build(iconf,ref_coefs):
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
 

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -62,8 +62,8 @@ def build():
         trainsel,
         nspe1,
         nspe2,
-        HYPER_PARAMETERS_DENSITY,
-        HYPER_PARAMETERS_POTENTIAL,
+        HP1,
+        HP2,
     ) = ParseConfig().get_all_params()
 
     comm, size, rank, parallel = detect_mpi()

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -38,7 +38,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     if filename_pred == PLACEHOLDER or predname == PLACEHOLDER:
         raise ValueError(
@@ -122,8 +122,13 @@ def build():
     frames = [frames[i] for i in conf_range]
 
     # Compute atom-density spherical expansion coefficients
-    omega1 = sph_utils.get_representation_coeffs(frames,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms_total)
-    omega2 = sph_utils.get_representation_coeffs(frames,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms_total)
+    omega1 = sph_utils.get_representation_coeffs(
+        frames, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms_total)
+    if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+        omega2 = omega1
+    else:
+        omega2 = sph_utils.get_representation_coeffs(
+            frames, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms_total)
 
     # Reshape arrays of expansion coefficients for optimal Fortran indexing
     v1 = np.transpose(omega1,(1,3,0,2)).copy()

--- a/salted/rkhs_projector.py
+++ b/salted/rkhs_projector.py
@@ -26,7 +26,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)

--- a/salted/rkhs_vector.py
+++ b/salted/rkhs_vector.py
@@ -33,7 +33,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     comm, size, rank, parallel = detect_mpi()
 
@@ -113,8 +113,13 @@ def build():
 
             structure = frames[iconf]
 
-            omega1 = sph_utils.get_representation_coeffs(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms[iconf])
-            omega2 = sph_utils.get_representation_coeffs(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms[iconf])
+            omega1 = sph_utils.get_representation_coeffs(
+                structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms[iconf])
+            if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+                omega2 = omega1
+            else:
+                omega2 = sph_utils.get_representation_coeffs(
+                    structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms[iconf])
 
             # Reshape arrays of expansion coefficients for optimal Fortran indexing
             v1 = np.transpose(omega1,(1,3,0,2)).copy()
@@ -264,8 +269,13 @@ def build():
 
             structure = frames[iconf]
 
-            omega1 = sph_utils.get_representation_coeffs(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms[iconf])
-            omega2 = sph_utils.get_representation_coeffs(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms[iconf])
+            omega1 = sph_utils.get_representation_coeffs(
+                structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms[iconf])
+            if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+                omega2 = omega1
+            else:
+                omega2 = sph_utils.get_representation_coeffs(
+                    structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms[iconf])
 
             # Reshape arrays of expansion coefficients for optimal Fortran indexing
             v1 = np.transpose(omega1,(2,0,3,1))

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -24,7 +24,7 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     start_time = time.time()
 
@@ -78,8 +78,13 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
     
     if gradient:
     
-        omega1, domega1 = sph_utils.get_representation_gradient_coeffs_atomrange(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms_tot,atomic_global_idx[atoms_range])
-        omega2, domega2 = sph_utils.get_representation_gradient_coeffs_atomrange(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms_tot,atomic_global_idx[atoms_range])
+        omega1, domega1 = sph_utils.get_representation_gradient_coeffs_atomrange(
+            structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms_tot, atomic_global_idx[atoms_range])
+        if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+            omega2, domega2 = omega1, domega1
+        else:
+            omega2, domega2 = sph_utils.get_representation_gradient_coeffs_atomrange(
+                structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms_tot, atomic_global_idx[atoms_range])
     
         dv1 = np.transpose(domega1.reshape((domega1.shape[0],natoms_range,natoms_tot,3,domega1.shape[3],domega1.shape[4])),(1,5,0,4,2,3)).copy()
         dv2 = np.transpose(domega2.reshape((domega2.shape[0],natoms_range,natoms_tot,3,domega2.shape[3],domega2.shape[4])),(1,5,0,4,2,3)).copy()
@@ -88,8 +93,13 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
    
     else: 
 
-        omega1 = sph_utils.get_representation_coeffs_atomrange(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,atomic_global_idx[atoms_range])
-        omega2 = sph_utils.get_representation_coeffs_atomrange(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,atomic_global_idx[atoms_range])
+        omega1 = sph_utils.get_representation_coeffs_atomrange(
+            structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, atomic_global_idx[atoms_range])
+        if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+            omega2 = omega1
+        else:
+            omega2 = sph_utils.get_representation_coeffs_atomrange(
+                structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, atomic_global_idx[atoms_range])
    
     v1 = np.transpose(omega1,(1,3,0,2)).copy()
     v2 = np.transpose(omega2,(1,3,0,2)).copy()

--- a/salted/scalar_vector.py
+++ b/salted/scalar_vector.py
@@ -27,7 +27,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     sdir = osp.join(saltedpath, f"equirepr_{saltedname}")
 
@@ -60,8 +60,11 @@ def build():
     ))
     wigdim = wigner3j.size
 
-    omega1 = sph_utils.get_representation_coeffs(frames,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,0,neighspe1,species,nang1,nrad1,natoms_total)
-    omega2 = sph_utils.get_representation_coeffs(frames,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,0,neighspe2,species,nang2,nrad2,natoms_total)
+    omega1 = sph_utils.get_representation_coeffs(frames, rep1, HP1, 0, neighspe1, species, nang1, nrad1, natoms_total)
+    if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+        omega2 = omega1
+    else:
+        omega2 = sph_utils.get_representation_coeffs(frames, rep2, HP2, 0, neighspe2, species, nang2, nrad2, natoms_total)
 
     # Reshape arrays of expansion coefficients for optimal Fortran indexing 
     v1 = np.transpose(omega1,(1,3,0,2)).copy()

--- a/salted/sparse_descriptor.py
+++ b/salted/sparse_descriptor.py
@@ -39,7 +39,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     comm, size, rank, parallel = detect_mpi()
 
@@ -115,8 +115,13 @@ def build():
             structure = frames[iconf]
 
             # Compute spherical harmonics expansion coefficients
-            omega1 = sph_utils.get_representation_coeffs(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms[iconf])
-            omega2 = sph_utils.get_representation_coeffs(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms[iconf])
+            omega1 = sph_utils.get_representation_coeffs(
+                structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms[iconf])
+            if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+                omega2 = omega1
+            else:
+                omega2 = sph_utils.get_representation_coeffs(
+                    structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms[iconf])
 
             # Reshape arrays of expansion coefficients for optimal Fortran indexing
             v1 = np.transpose(omega1,(1,3,0,2)).copy()
@@ -199,9 +204,14 @@ def build():
             structure = frames[iconf]
     
             # Compute spherical harmonics expansion coefficients
-            omega1 = sph_utils.get_representation_coeffs(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms[iconf])
-            omega2 = sph_utils.get_representation_coeffs(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms[iconf])
-    
+            omega1 = sph_utils.get_representation_coeffs(
+                structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms[iconf])
+            if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+                omega2 = omega1
+            else:
+                omega2 = sph_utils.get_representation_coeffs(
+                    structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms[iconf])
+
             # Reshape arrays of expansion coefficients for optimal Fortran indexing
             v1 = np.transpose(omega1,(2,0,3,1))
             v2 = np.transpose(omega2,(2,0,3,1))
@@ -267,8 +277,13 @@ def build():
             structure = frames[iconf]
 
             # Compute spherical harmonics expansion coefficients
-            omega1 = sph_utils.get_representation_coeffs(structure,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe1,species,nang1,nrad1,natoms[iconf])
-            omega2 = sph_utils.get_representation_coeffs(structure,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe2,species,nang2,nrad2,natoms[iconf])
+            omega1 = sph_utils.get_representation_coeffs(
+                structure, rep1, HP1, rank, neighspe1, species, nang1, nrad1, natoms[iconf])
+            if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+                omega2 = omega1
+            else:
+                omega2 = sph_utils.get_representation_coeffs(
+                    structure, rep2, HP2, rank, neighspe2, species, nang2, nrad2, natoms[iconf])
 
             # Reshape arrays of expansion coefficients for optimal Fortran indexing
             v1 = np.transpose(omega1,(2,0,3,1))

--- a/salted/sparsify_features.py
+++ b/salted/sparsify_features.py
@@ -26,7 +26,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     # Generate directories for saving descriptors
     sdir = osp.join(saltedpath, f"equirepr_{saltedname}")
@@ -66,8 +66,11 @@ def build():
     natoms = list( natoms[i] for i in conf_range )
     natoms_total = sum(natoms)
 
-    omega1 = sph_utils.get_representation_coeffs(frames,rep1,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,0,neighspe1,species,nang1,nrad1,natoms_total)
-    omega2 = sph_utils.get_representation_coeffs(frames,rep2,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,0,neighspe2,species,nang2,nrad2,natoms_total)
+    omega1 = sph_utils.get_representation_coeffs(frames, rep1, HP1, 0, neighspe1, species, nang1, nrad1, natoms_total)
+    if sph_utils.reps_equivalent(rep1, neighspe1, HP1, rep2, neighspe2, HP2):
+        omega2 = omega1
+    else:
+        omega2 = sph_utils.get_representation_coeffs(frames, rep2, HP2, 0, neighspe2, species, nang2, nrad2, natoms_total)
 
     # Reshape arrays of expansion coefficients for optimal Fortran indexing
     v1 = np.transpose(omega1,(2,0,3,1))

--- a/salted/sph_utils.py
+++ b/salted/sph_utils.py
@@ -1,10 +1,9 @@
 import sys
 import math
 import time
-from typing import Tuple
-
 import numpy as np
 from scipy import special
+from ase import Atoms
 from ase.data import atomic_numbers
 
 from featomic import SphericalExpansion
@@ -91,7 +90,7 @@ def complex_to_real_transformation(sizes):
 
     return matrices
 
-def get_angular_indexes_symmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]:
+def get_angular_indexes_symmetric(lam,nang1,nang2) -> tuple[int, np.ndarray]:
     """Select relevant angular indexes for equivariant descriptor calculation"""
 
     llmax = 0
@@ -114,7 +113,7 @@ def get_angular_indexes_symmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]:
 
     return llmax, llvec
 
-def get_angular_indexes_antisymmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]:
+def get_angular_indexes_antisymmetric(lam,nang1,nang2) -> tuple[int, np.ndarray]:
     """Select relevant angular indexes for equivariant descriptor calculation, antisymmetric with respect to inversion operations"""
 
     llmax = 0
@@ -137,18 +136,46 @@ def get_angular_indexes_antisymmetric(lam,nang1,nang2) -> Tuple[int, np.ndarray]
 
     return llmax, llvec
 
-def get_representation_coeffs(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe,species,nang,nrad,natoms):
-    """Compute spherical harmonics expansion coefficients of the given structural representation."""
+def reps_equivalent(
+    rep1: str, neighspe1: list[str], hyper_params1: dict,
+    rep2: str, neighspe2: list[str], hyper_params2: dict,
+) -> bool:
+    """Return True if two rep configs are identical (same type, neighbor species, and hyperparameters).
+
+    When True, the caller can reuse omega1 for omega2 instead of recomputing.
+    """
+    return rep1 == rep2 and list(neighspe1) == list(neighspe2) and hyper_params1 == hyper_params2
+
+
+def get_representation_coeffs(
+    structure: Atoms, rep: str, hyper_params: dict,
+    rank: int, neighspe: list[str], species: list[str],
+    nang: int, nrad: int, natoms: int,
+) -> np.ndarray:
+    """Compute spherical harmonics expansion coefficients of the given structural representation.
+
+    Args:
+        structure (Atoms): ASE Atoms object.
+        rep (str): representation type, "rho" (SOAP) or "V" (LODE).
+        hyper_params (dict): featomic hyperparameter dict for this representation,
+                             as returned by sys_utils.build_featomic_hyper_params().
+        rank (int): MPI rank (used for error messages).
+        neighspe (list[str]): neighbor species list.
+        species (list[str]): center species list.
+        nang (int): max angular channel.
+        nrad (int): number of radial basis functions.
+        natoms (int): number of atoms in the structure.
+    """
 
     if rep=="rho":
 
         # get SPH expansion for atomic density
-        calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
+        calculator = SphericalExpansion(**hyper_params)
 
     elif rep=="V":
 
         # get SPH expansion for atomic potential
-        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+        calculator = LodeSphericalExpansion(**hyper_params)
 
     else:
 
@@ -180,18 +207,35 @@ def get_representation_coeffs(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAM
 
     return omega
 
-def get_representation_coeffs_atomrange(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe,species,nang,nrad,atoms_range):
-    """Compute spherical harmonics expansion coefficients of the given structural representation."""
+def get_representation_coeffs_atomrange(
+    structure: Atoms, rep: str, hyper_params: dict,
+    rank: int, neighspe: list[str], species: list[str],
+    nang: int, nrad: int, atoms_range: np.ndarray,
+) -> np.ndarray:
+    """Compute spherical harmonics expansion coefficients of the given structural representation.
+
+    Args:
+        structure (Atoms): ASE Atoms object.
+        rep (str): representation type, "rho" (SOAP) or "V" (LODE).
+        hyper_params (dict): featomic hyperparameter dict for this representation,
+                             as returned by sys_utils.build_featomic_hyper_params().
+        rank (int): MPI rank (used for error messages).
+        neighspe (list[str]): neighbor species list.
+        species (list[str]): center species list.
+        nang (int): max angular channel.
+        nrad (int): number of radial basis functions.
+        atoms_range (np.ndarray): indices of atoms to compute.
+    """
 
     if rep=="rho":
 
         # get SPH expansion for atomic density
-        calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
+        calculator = SphericalExpansion(**hyper_params)
 
     elif rep=="V":
 
         # get SPH expansion for atomic potential
-        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+        calculator = LodeSphericalExpansion(**hyper_params)
 
     else:
 
@@ -232,16 +276,33 @@ def get_representation_coeffs_atomrange(structure,rep,HYPER_PARAMETERS_DENSITY,H
 
     return omega
 
-def get_representation_gradient_coeffs(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe,species,nang,nrad,natoms):
-    """Compute spherical harmonics expansion coefficients of the given structural representation."""
+def get_representation_gradient_coeffs(
+    structure: Atoms, rep: str, hyper_params: dict,
+    rank: int, neighspe: list[str], species: list[str],
+    nang: int, nrad: int, natoms: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute spherical harmonics expansion coefficients and their position gradients.
+
+    Args:
+        structure (Atoms): ASE Atoms object.
+        rep (str): representation type, "rho" (SOAP) or "V" (LODE).
+        hyper_params (dict): featomic hyperparameter dict for this representation,
+                             as returned by sys_utils.build_featomic_hyper_params().
+        rank (int): MPI rank (used for error messages).
+        neighspe (list[str]): neighbor species list.
+        species (list[str]): center species list.
+        nang (int): max angular channel.
+        nrad (int): number of radial basis functions.
+        natoms (int): number of atoms in the structure.
+    """
 
     if rep=="rho":
         # get SPH expansion for atomic density
-        calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
+        calculator = SphericalExpansion(**hyper_params)
 
     elif rep=="V":
         # get SPH expansion for atomic potential
-        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+        calculator = LodeSphericalExpansion(**hyper_params)
 
     else:
         if rank == 0: print("Error: requested representation", rep, "not provided")
@@ -292,16 +353,34 @@ def get_representation_gradient_coeffs(structure,rep,HYPER_PARAMETERS_DENSITY,HY
 
     return omega, domega
 
-def get_representation_gradient_coeffs_atomrange(structure,rep,HYPER_PARAMETERS_DENSITY,HYPER_PARAMETERS_POTENTIAL,rank,neighspe,species,nang,nrad,natoms,atoms_range):
-    """Compute spherical harmonics expansion coefficients of the given structural representation."""
+def get_representation_gradient_coeffs_atomrange(
+    structure: Atoms, rep: str, hyper_params: dict,
+    rank: int, neighspe: list[str], species: list[str],
+    nang: int, nrad: int, natoms: int, atoms_range: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute spherical harmonics expansion coefficients and position gradients for a subset of atoms.
+
+    Args:
+        structure (Atoms): ASE Atoms object.
+        rep (str): representation type, "rho" (SOAP) or "V" (LODE).
+        hyper_params (dict): featomic hyperparameter dict for this representation,
+                             as returned by sys_utils.build_featomic_hyper_params().
+        rank (int): MPI rank (used for error messages).
+        neighspe (list[str]): neighbor species list.
+        species (list[str]): center species list.
+        nang (int): max angular channel.
+        nrad (int): number of radial basis functions.
+        natoms (int): total number of atoms in the structure.
+        atoms_range (np.ndarray): indices of atoms to compute.
+    """
 
     if rep=="rho":
         # get SPH expansion for atomic density
-        calculator = SphericalExpansion(**HYPER_PARAMETERS_DENSITY)
+        calculator = SphericalExpansion(**hyper_params)
 
     elif rep=="V":
         # get SPH expansion for atomic potential
-        calculator = LodeSphericalExpansion(**HYPER_PARAMETERS_POTENTIAL)
+        calculator = LodeSphericalExpansion(**hyper_params)
 
     else:
         if rank == 0: print("Error: requested representation", rep, "not provided")

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -14,6 +14,46 @@ from ase.io import read
 from salted import basis
 
 
+def build_featomic_hyper_params(rep_cfg) -> dict:
+    """Return the featomic kwargs dict for a single representation config.
+
+    Args:
+        rep_cfg: a rep config object with fields type, rcut, sig, nrad, nang
+                 (as returned by inp.descriptor.rep1 / rep2).
+
+    Returns:
+        dict: hyperparameter dict ready to be passed to SphericalExpansion
+              (for type="rho") or LodeSphericalExpansion (for type="V").
+    """
+    if rep_cfg.type == "rho":
+        return {
+            "cutoff": {"radius": rep_cfg.rcut, "smoothing": {"type": "ShiftedCosine", "width": 0.1}},
+            "density": {"type": "Gaussian", "width": rep_cfg.sig},
+            "basis": {
+                "type": "TensorProduct",
+                "max_angular": rep_cfg.nang,
+                "radial": {"type": "Gto", "max_radial": rep_cfg.nrad - 1},
+                "spline_accuracy": 1e-06,
+            },
+        }
+    elif rep_cfg.type == "V":
+        return {
+            "density": {"type": "SmearedPowerLaw", "smearing": rep_cfg.sig, "exponent": 1},
+            "basis": {
+                "type": "TensorProduct",
+                "max_angular": rep_cfg.nang,
+                "radial": {
+                    "type": "Gto",
+                    "max_radial": rep_cfg.nrad - 1,
+                    "radius": rep_cfg.rcut,
+                },
+                "spline_accuracy": 1e-06,
+            },
+        }
+    else:
+        raise ValueError(f"Unknown representation type '{rep_cfg.type}': must be 'rho' or 'V'.")
+
+
 def read_system(filename: str = None, spelist: List[str] = None, dfbasis: str = None):
     """read a geometry file and return the formatted information
 
@@ -571,58 +611,19 @@ class ParseConfig:
          rep2, rcut2, sig2, nrad2, nang2, neighspe2,
          sparsify, nsamples, ncut,
          zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-         gradtol, restart, trainsel) = ParseConfig().get_all_params()
+         gradtol, restart, trainsel,
+         nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
         ```
+        HP1 and HP2 are the featomic hyperparameter dicts for rep1 and rep2,
+        built from their respective configs via build_featomic_hyper_params().
         """
         inp = self.parse_input()
         sparsify = False if inp.descriptor.sparsify.ncut <= 0 else True  # determine if sparsify by ncut
         nspe1 = len(inp.descriptor.rep1.neighspe)
         nspe2 = len(inp.descriptor.rep2.neighspe)
 
-        # HYPER_PARAMETERS_DENSITY = {
-        #    "cutoff": inp.descriptor.rep1.rcut,
-        #    "max_radial": inp.descriptor.rep1.nrad,
-        #    "max_angular": inp.descriptor.rep1.nang,
-        #    "atomic_gaussian_width": inp.descriptor.rep1.sig,
-        #    "center_atom_weight": 1.0,
-        #    "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
-        #    "cutoff_function": {"ShiftedCosine": {"width": 0.1}},
-        # }
-
-        HYPER_PARAMETERS_DENSITY = {
-            "cutoff": {"radius": inp.descriptor.rep1.rcut, "smoothing": {"type": "ShiftedCosine", "width": 0.1}},
-            "density": {"type": "Gaussian", "width": inp.descriptor.rep1.sig},
-            "basis": {
-                "type": "TensorProduct",
-                "max_angular": inp.descriptor.rep1.nang,
-                "radial": {"type": "Gto", "max_radial": inp.descriptor.rep1.nrad - 1},
-                "spline_accuracy": 1e-06,
-            },
-        }
-
-        # HYPER_PARAMETERS_POTENTIAL = {
-        #    "potential_exponent": 1,
-        #    "cutoff": inp.descriptor.rep2.rcut,
-        #    "max_radial": inp.descriptor.rep2.nrad,
-        #    "max_angular": inp.descriptor.rep2.nang,
-        #    "atomic_gaussian_width": inp.descriptor.rep2.sig,
-        #    "center_atom_weight": 1.0,
-        #    "radial_basis": {"Gto": {"spline_accuracy": 1e-6}},
-        # }
-
-        HYPER_PARAMETERS_POTENTIAL = {
-            "density": {"type": "SmearedPowerLaw", "smearing": inp.descriptor.rep2.sig, "exponent": 1},
-            "basis": {
-                "type": "TensorProduct",
-                "max_angular": inp.descriptor.rep2.nang,
-                "radial": {
-                    "type": "Gto",
-                    "max_radial": inp.descriptor.rep2.nrad - 1,
-                    "radius": inp.descriptor.rep2.rcut,
-                },
-                "spline_accuracy": 1e-06,
-            },
-        }
+        HP1 = build_featomic_hyper_params(inp.descriptor.rep1)
+        HP2 = build_featomic_hyper_params(inp.descriptor.rep2)
 
         return (
             inp.salted.saltedname,
@@ -665,8 +666,8 @@ class ParseConfig:
             inp.gpr.trainsel,
             nspe1,
             nspe2,
-            HYPER_PARAMETERS_DENSITY,
-            HYPER_PARAMETERS_POTENTIAL,
+            HP1,
+            HP2,
         )
 
     def get_all_params_simple1(self) -> Tuple:

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -30,7 +30,7 @@ def build():
     rep2, rcut2, sig2, nrad2, nang2, neighspe2,
     sparsify, nsamples, ncut,
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
-    gradtol, restart, trainsel, nspe1, nspe2, HYPER_PARAMETERS_DENSITY, HYPER_PARAMETERS_POTENTIAL) = ParseConfig().get_all_params()
+    gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
     comm, size, rank, parallel = detect_mpi()
 


### PR DESCRIPTION
Fix issue #72: unwanted type assumption in descriptor hyperparameters

## Summary
- **Bug fix**: `get_all_params()` in `sys_utils.py` previously hardcoded `rep1` as the `"rho"` hyperparameters and `rep2` as the `"V"` hyperparameters, regardless of the actual type field. This silently produced wrong descriptors for any configuration other than `rep1.type=rho` + `rep2.type=V`.
- **Improvement**: Add `build_featomic_hyper_params(rep_cfg)` as a single source of truth for featomic kwargs, dispatching on `rep_cfg.type`. Each rep now carries its own correct hyperparameter dict `(HP1, HP2)`.
- **Efficiency**: When `rep1` and `rep2` are fully equivalent (same type, neighbor species, and hyperparameters), the spherical expansion is computed only once and reused via `reps_equivalent()`, saving descriptor computation time in that common case.
- **API cleanup**: The 4 `get_representation_*()` functions in `sph_utils.py` now take a single hyper_params dict instead of two separate density/potential dicts. Type annotations added to all updated function signatures.

## Test
Passed the water monomer test and got identical results compared to previous results.

## Note
Please double-check: "same type, neighbor species, and hyperparameters" ensures exactly the same descriptor.
Further test: on density response, and other jobs besides full nuclei density predictions.
