### PR TITLE
Modernize Type Hints with PEP 585 and PEP 604

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -27,7 +27,7 @@ For all the path-related variables, the path can be either a relative path or an
 | var name | type | default | usage |
 | -:| :-: | :-: | :- |
 | `filename` | `str` | **Required** | An extended-XYZ file consisting of input structures. |
-| `species` | `List[str]` | **Required** | List of element species considered in the electron density expansion. |
+| `species` | `list[str]` | **Required** | List of element species considered in the electron density expansion. |
 | `average` | `bool` | `True` | Whether we use averaged coefficients to set a baseline for the density. Normally this should be true, unless a density difference is learned. |
 
 ### Information about QM training set generation `inp.qm`
@@ -35,7 +35,7 @@ For all the path-related variables, the path can be either a relative path or an
 | var name | type | default | usage |
 | -:| :-: | :-: | :- |
 | `path2qm` | `str` | **Required** | Location of the quantum-mechanical training data. |
-| `qmcode` | `Union[Literal["aims"], Literal["cp2k"], Literal["pyscf"]]` | **Required** | Which ab initio software was used to generate training data. |
+| `qmcode` | `Literal["aims"] \| Literal["cp2k"] \| Literal["pyscf"]` | **Required** | Which ab initio software was used to generate training data. |
 | `dfbasis` | `str` | **Required** | A label for the auxiliary basis set used to expand the density. |
 | `qmbasis` | `str` | Required if `qmcode=pyscf` | Wavefunction basis set to use when generating the training data (only for PySCF). |
 | `functional` | `str` | Required if `qmcode=pyscf` | DFT functional to use when generating the training data (only for PySCF). |
@@ -48,12 +48,12 @@ For all the path-related variables, the path can be either a relative path or an
 
 | var name | type | default | usage |
 | -:| :-: | :-: | :- |
-| `type` | `Union[Literal["rho"], Literal["V"]]` | **Required** | Representation type, `"rho"` for atomic density and `"V"` for atomic potential. |
+| `type` | `Literal["rho"] \| Literal["V"]` | **Required** | Representation type, `"rho"` for atomic density and `"V"` for atomic potential. |
 | `rcut` | `float` | **Required** | Radial cutoff (Angstrom) of the structural representation. |
 | `nrad` | `int` | **Required** | Number of radial functions to be used for the structural representation. |
 | `nang` | `int` | **Required** | Maximum angular momentum to be used for the structural representation. |
 | `sig` | `float` | **Required** | Gaussian function width (Angstrom) for atomic density and/or derived atomic potential. |
-| `neighspe` | `List[str]` | **Required** | List of atomic species to be used for structural representation. |
+| `neighspe` | `list[str]` | **Required** | List of atomic species to be used for structural representation. |
 
 ### Feature sparsification parameters `inp.descriptor.sparsify`
 
@@ -85,8 +85,8 @@ Remember to set `inp.predict` if one wants to predict densities.
 | `eigcut` | `float` | `1e-10` | Eigenvalues cutoff for RKHS projection. |
 | `gradtol` | `float` | `1e-5` | Minimum gradient norm tolerance for CG minimization. |
 | `restart` | `bool` | `False` | Whether to restart from previous minimization checkpoint. |
-| `trainsel` | `Union[Literal["sequential"], Literal["random"]]` | `"random"` | Select the training set at random or sequentially from the entire dataset. |
-| `sparse_algorithm` | `Union[Literal["dense"], Literal["omp_sparse"]]` | `"omp_sparse"` | The algorithm to compute Hessian matrices, if making use of the RKHS vector sparsity. |
+| `trainsel` | `Literal["sequential"] \| Literal["random"]` | `"random"` | Select the training set at random or sequentially from the entire dataset. |
+| `sparse_algorithm` | `Literal["dense"] \| Literal["omp_sparse"]` | `"omp_sparse"` | The algorithm to compute Hessian matrices, if making use of the RKHS vector sparsity. |
 
 ---
 

--- a/docs/tutorial/dataset.md
+++ b/docs/tutorial/dataset.md
@@ -15,22 +15,22 @@ Whichever code is used, the result should be the generation of new directories n
 
 ### PySCF
 
-1. The following input arguments must be added to the `inp.qm` section:  
+1. The following input arguments must be added to the `inp.qm` section:
     - `qmcode`: define the quantum-mechanical code as `pyscf`
-    - `path2qm`: set the path where the PySCF data are going to be saved 
+    - `path2qm`: set the path where the PySCF data are going to be saved
     - `qmbasis`: define the wave function basis set for the Kohn-Sham calculation (example: `cc-pvqz`)
     - `functional`: define the functional for the Kohn-Sham calculation (example: `b3lyp`)
 1. Define the auxiliary basis set using the input variable `dfbasis`, as provided in the `inp.qm` section. This must be chosen consistently with the wave function basis set (example: `RI-cc-pvqz`). Then, add this basis set information to SALTED by running:
 ```bash
-   python3 -m salted.get_basis_info
+python3 -m salted.get_basis_info
 ```
-1. Run PySCF to compute the Kohn-Sham density matrices: 
+1. Run PySCF to compute the Kohn-Sham density matrices:
 ```bash
-   python3 -m salted.pyscf.run_pyscf
+python3 -m salted.pyscf.run_pyscf
 ```
-1. From the computed density matrices, perform the density fitting on the selected auxiliary basis set by running: 
+1. From the computed density matrices, perform the density fitting on the selected auxiliary basis set by running:
 ```bash
-   python3 -m salted.pyscf.dm2df
+python3 -m salted.pyscf.dm2df
 ```
 
 ### FHI-aims
@@ -40,31 +40,31 @@ A detailed description of how to generate the training data for SALTED using FHI
 
 ### CP2K
 
-1. The following input arguments must be added to the `inp.qm` section:
+1. The following input arguments must be included in the `inp.qm` section:
     - `qmcode`: define quantum-mechanical code as `cp2k`
     - `path2qm`: set the path where the CP2K data are going to be saved
     - `periodic`: set the periodicity of the system (`0D,2D,3D`)
     - `coeffile`: filename of RI density coefficients as printed by CP2K
-    - `ovlpfile`: filename of 2-center auxiliary integrals as printed by CP2K
-    - `dfbasis`: define auxiliary basis for the electron density expansion
-    - `pseudocharge`: define pseudocharge according to the adopted GTH pseudopotential
+    - `ovlpfile`: filename of 2-center RI integrals as printed by CP2K
+    - `dfbasis`: RI (density-fitting) basis filename appended for each species, extracted from CP2K
+    - `pseudocharge`: list of pseudocharges associated with the adopted GTH pseudopotential. **NB:** the list ordering must be consistent with the ordering of species provided in `inp.system.species`.
 1. Initialize the systems used for the CP2K calculation by running:
-```bash
-   python3 -m salted.cp2k.xyz2sys
-```
-   System cells and coordinates will be automatically saved in folders named `conf_1`, `conf_2`, ... up to the total number of structures included in the dataset, located into the selected `inp.qm.path2qm`. 
-1. Print auxiliary basis set information from the CP2K automatically generated RI basis set, as described in https://doi.org/10.1021/acs.jctc.6b01041. An example of a CP2K input file can be found in `cp2k-inputs/get_RI-AUTO_basis.inp`. 
-1. An uncontracted version of this basis can be produced to increase the efficiency of the RI printing workflow, by running:
-```bash
-   python3 -m salted.cp2k.uncontract_ri_basis contracted_basis_file uncontracted_basis_file
-```
-   Then, copy `uncontracted_basis_file` to the `cp2k/data/` folder in order to use this basis set to produce the reference density-fitting data, and set the corresponding filename in the `inp.qm.dfbasis` input variable.
-1. Add the selected auxiliary basis to SALTED by running:
-```bash
-   python3 -m salted.get_basis_info
-```
-1. Run the CP2K calculations using the selected auxiliary basis and print out the training data made of reference RI coefficients and 2-center auxiliary integrals. An example of a CP2K input file can be found in `cp2k-inputs/qmmm_RI-print.inp`. 
-1. Set the `inp.qm.coeffile` and `inp.qm.ovlpfile` variables according to the filename of the generated training data and convert them to SALTED format by running:
-```bash
-   python3 -m salted.cp2k.cp2k2salted
-```
+    ```bash
+    python3 -m salted.cp2k.xyz2sys
+    ```
+   System cells and coordinates are extracted from the configuration dataset in XYZ format and saved in folders named `conf_1`, `conf_2`, ... located in the path `inp.qm.path2qm`. **NB:** cell information (`Lattice`) must be included in second line of each XYZ configuration, even if it does not change.
+1. Run SCF calculations and save the optimized wavefunction for each configuration in the corresponding folders previously generated. An example CP2K input is provided in `cp2k-inputs/SCF.inp`.
+1. Print the RI density-fitting coefficients and 2-center RI integrals by restarting the CP2K calculation from the optimized wavefunction. This restart operation derives from the large memory required by the RI fitting procedure, which might require using larger computational resources than the plain SCF cycle. An example CP2K input is provided in `cp2k-inputs/rho-RI-print.inp`. **NB:** The RI basis is automatically generated by CP2K from the selected wavefunction basis set, as described in https://doi.org/10.1021/acs.jctc.6b01041, following SMALL, MEDIUM, or LARGE tiers.
+1. Print the RI basis set information required for SALTED postprocessing of the CP2K density. An example CP2K input is provided in `cp2k-inputs/RI-basis.inp`. This operation can be performed only once for any arbitrary configuration included in the dataset adopting the given choice of RI basis. The output is a single file including wavefunction and RI basis set information of all the species included in the selected test configuration. To extract the RI basis information for each species, run
+    ```bash
+    python3 -m salted.cp2k.extract_basis cp2k_basis_filename
+    ```
+    with `cp2k_basis_filename` the output basis set filename. This will create a separate file for each species in the format, e.g., H-`dfbasis`, O-`dfbasis`.
+1. Add the RI basis set information to SALTED by running:
+    ```bash
+    python3 -m salted.get_basis_info
+    ```
+1. Set the `inp.qm.coeffile` and `inp.qm.ovlpfile` input arguments according to the filenames of the RI density-fitting coefficients and 2-center RI integrals generated at step 4. Then, convert the full training dataset in SALTED format by running:
+    ```bash
+    python3 -m salted.cp2k.cp2k2salted
+    ```

--- a/salted/aims/get_basis_info.py
+++ b/salted/aims/get_basis_info.py
@@ -1,6 +1,5 @@
 """Translate basis info from FHI-aims calculation to SALTED basis info"""
 import os
-from typing import Dict, List
 from ase.io import read
 
 from salted.basis_client import (
@@ -23,7 +22,7 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
     spe_set = set(inp.system.species)
     geoms_list = read(inp.system.filename, ":")
     qmdata_dpath = os.path.join(inp.qm.path2qm, "data")
-    basis_data: Dict[str, SpeciesBasisData] = {}  # hold all species basis data
+    basis_data: dict[str, SpeciesBasisData] = {}  # hold all species basis data
 
     for iconf, geom in enumerate(geoms_list):
         """parse basis_info.out for this geometry"""
@@ -70,7 +69,7 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
         BasisClient().write(inp.qm.dfbasis, basis_data, force_overwrite)
 
 
-def parse_file_basis_info(basis_info_fpath: str) -> List[SpeciesBasisData]:
+def parse_file_basis_info(basis_info_fpath: str) -> list[SpeciesBasisData]:
     """Parse basis_info.out by FHI-aims.
     Parse by str.strip().split().
 
@@ -115,7 +114,7 @@ def parse_file_basis_info(basis_info_fpath: str) -> List[SpeciesBasisData]:
     #     print(f"{lines_by_atoms=}")
 
     """Step 2: derive SpeciesBasisData and do some checks (to ensure the file is not corrupted)"""
-    basis_data: List[SpeciesBasisData] = []
+    basis_data: list[SpeciesBasisData] = []
     for lines_atom in lines_by_atoms:
         err_msg = f"{basis_info_fpath=}, {lines_atom=}"
         assert lines_atom[0][0] == "atom", err_msg  # check the first line

--- a/salted/basis_client.py
+++ b/salted/basis_client.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import sys
-from typing import Dict, List, Optional, Tuple, TypedDict
+from typing import TypedDict
 
 import yaml
 
@@ -11,7 +11,7 @@ class SpeciesBasisData(TypedDict):
     Satisfies: len(nmax) == lmax + 1, and nmax: [s, p, d, ...]
     """
     lmax: int
-    nmax: List[int]
+    nmax: list[int]
 
 def compare_species_basis_data(data1: SpeciesBasisData, data2: SpeciesBasisData):
     """Compare two species basis data.
@@ -21,8 +21,8 @@ def compare_species_basis_data(data1: SpeciesBasisData, data2: SpeciesBasisData)
     return pickle.dumps(data1) == pickle.dumps(data2)
 
 def compare_basis_data_dup_spe(
-    basis_data1: Dict[str, SpeciesBasisData],
-    basis_data2: Dict[str, SpeciesBasisData],
+    basis_data1: dict[str, SpeciesBasisData],
+    basis_data2: dict[str, SpeciesBasisData],
 ):
     """Compare two basis data.
     If the SpeciesBasisData for duplicated species are the same, return True.
@@ -82,7 +82,7 @@ class BasisClient:
 
     DEFAULT_DATA_FNAME = "basis_data.yaml"
 
-    def __init__(self, _dev_data_fpath: Optional[str] = None):
+    def __init__(self, _dev_data_fpath: str | None = None):
         """Initialize the basis client with the data file path.
 
         Args:
@@ -170,13 +170,13 @@ class BasisClient:
                     spe_data["lmax"] == len(spe_data["nmax"]) - 1
                 ), f"lmax nmax discrepancy: {basis_name=}, {spe_name=}, {spe_data=}"
 
-    def _read_all(self) -> Dict[str, Dict[str, SpeciesBasisData]]:
+    def _read_all(self) -> dict[str, dict[str, SpeciesBasisData]]:
         """Read all basis data from the dataset file"""
         with open(self.data_fpath) as f:
             basis_data_all = yaml.safe_load(f)
         return basis_data_all
 
-    def read(self, basis_name: str) -> Dict[str, SpeciesBasisData]:
+    def read(self, basis_name: str) -> dict[str, SpeciesBasisData]:
         """Read basis data from the dataset file"""
         basis_data_all = self._read_all()
         assert (
@@ -186,7 +186,7 @@ class BasisClient:
 
     def read_as_old_format(
         self, basis_name: str
-    ) -> Tuple[Dict[str, int], Dict[Tuple[str, int], int]]:
+    ) -> tuple[dict[str, int], dict[tuple[str, int], int]]:
         """Read basis data and return as the old format
 
         Old format:
@@ -217,14 +217,14 @@ class BasisClient:
         }
         return (lmax, nmax)
 
-    def _write_all(self, basis_data_all: Dict[str, Dict[str, SpeciesBasisData]]):
+    def _write_all(self, basis_data_all: dict[str, dict[str, SpeciesBasisData]]):
         """Rewrite the whole dataset file with the new basis data"""
         with open(self.data_fpath, "w") as f:
             yaml.safe_dump(
                 basis_data_all, f, default_flow_style=None
             )  # default_flow_style is important!
 
-    def write(self, basis_name: str, basis_data: Dict[str, SpeciesBasisData], force_overwrite: bool = False):
+    def write(self, basis_name: str, basis_data: dict[str, SpeciesBasisData], force_overwrite: bool = False):
         """Write basis data to the dataset file"""
         with open(self.data_fpath) as f:
             basis_data_all: Dict = yaml.safe_load(f)

--- a/salted/cp2k/get_basis_info.py
+++ b/salted/cp2k/get_basis_info.py
@@ -1,7 +1,6 @@
 """Translate basis info from CP2K calculation to SALTED basis info"""
 
 from itertools import islice
-from typing import Dict, Tuple, List
 
 import os
 import os.path as osp
@@ -28,7 +27,7 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
     lmax, nmax, alphas, contra = parse_files_basis_info(inp.system.species, inp.qm.dfbasis)
 
     """Convert to basis_client format"""
-    basis_data: Dict[str, SpeciesBasisData] = {}
+    basis_data: dict[str, SpeciesBasisData] = {}
     for spe in lmax.keys():
         assert lmax[spe] + 1 == len(
             [i for i in nmax.keys() if i[0] == spe]
@@ -59,8 +58,8 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
         BasisClient().write(inp.qm.dfbasis, basis_data, force_overwrite)
 
 
-def parse_files_basis_info(species:List[str], dfbasis:str) -> (
-    Tuple[Dict[str, int], Dict[Tuple[str, int], int], Dict[Tuple[str, int], np.ndarray]]
+def parse_files_basis_info(species: list[str], dfbasis: str) -> (
+    tuple[dict[str, int], dict[tuple[str, int], int], dict[tuple[str, int], np.ndarray]]
 ):
     """Parse the basis files of cp2k
     File naming convention: `[species]-[basis_name]`.

--- a/salted/omp_sparse.py
+++ b/salted/omp_sparse.py
@@ -8,8 +8,6 @@ This module provides a simple interface to the compiled OpenMP Fortran functions
 integrated into SALTED's build system.
 """
 
-from typing import Union
-
 import numpy as np
 import scipy.sparse
 
@@ -17,7 +15,8 @@ from salted.lib import omp_sparse as _omp_sparse_lib
 
 
 def dense_dot_sparse(
-    dense_matrix: np.ndarray, sparse_matrix: Union[scipy.sparse.coo_matrix, scipy.sparse.csc_matrix]
+    dense_matrix: np.ndarray,
+    sparse_matrix: scipy.sparse.coo_matrix | scipy.sparse.csc_matrix,
 ) -> np.ndarray:
     """
     Compute dense matrix matmul sparse_matrix using OpenMP acceleration.
@@ -65,7 +64,8 @@ def dense_dot_sparse(
 
 
 def sparse_transpose_dot_dense(
-    sparse_matrix: Union[scipy.sparse.coo_matrix, scipy.sparse.csc_matrix], dense_matrix: np.ndarray
+    sparse_matrix: scipy.sparse.coo_matrix | scipy.sparse.csc_matrix,
+    dense_matrix: np.ndarray,
 ) -> np.ndarray:
     """
     Compute sparse_matrix.T matmul dense matrix or dense vector using OpenMP acceleration.

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -2,7 +2,6 @@ import os
 import os.path as osp
 import sys
 import time
-from typing import Dict, List
 
 import h5py
 import numpy as np
@@ -583,7 +582,7 @@ def build():
     if rank == 0: print(f"\ntotal time: {(time.time()-start):.2f} s")
 
 
-def save_pred_descriptor(data:Dict[int, np.ndarray], config_range:List[int], natoms:List[int], dpath:str):
+def save_pred_descriptor(data: dict[int, np.ndarray], config_range: list[int], natoms: list[int], dpath: str):
     """Save the descriptor data of the prediction dataset.
 
     Args:
@@ -611,7 +610,7 @@ def save_pred_descriptor(data:Dict[int, np.ndarray], config_range:List[int], nat
 
     """ cut natmax to the number of atoms in the structure """
     for idx, idx_in_full_dataset in enumerate(config_range):
-        this_data:Dict[int, np.ndarray] = dict()
+        this_data: dict[int, np.ndarray] = dict()
         this_natoms = natoms[idx]
         for lam, data_this_lam in data.items():
             this_data[f"lam{lam}"] = data_this_lam[idx, :this_natoms]  # shape (natom, [2*lambda+1,] featsize)

--- a/salted/pyscf/dm2df.py
+++ b/salted/pyscf/dm2df.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import os.path as osp
 import time
-from typing import Dict, List, Tuple, Union
 
 import numpy as np
 from ase.io import read
@@ -21,7 +20,7 @@ Make sure to provide the density matrix following this convention!
 
 
 def cal_df_coeffs(
-    atoms: List,
+    atoms: list,
     qmbasis: str,
     ribasis: str,
     dm: np.ndarray,
@@ -92,7 +91,7 @@ def cal_df_coeffs(
 #print >> f, e_Ne
 #f.close()
 
-def main(geom_indexes: Union[List[int], None], num_threads: int = None):
+def main(geom_indexes: list[int] | None, num_threads: int = None):
     # global reorder_time, pyscf_time
     inp = ParseConfig().parse_input()
     

--- a/salted/pyscf/get_basis_info.py
+++ b/salted/pyscf/get_basis_info.py
@@ -1,7 +1,5 @@
 """Translate basis info from PySCF calculation to SALTED basis info"""
 
-from typing import Dict, List
-
 from pyscf import df
 from pyscf.gto import basis
 
@@ -25,7 +23,7 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
     qmbasis = inp.qm.qmbasis
 
     """load density fitting basis from pyscf module"""
-    basis_data: Dict[str, SpeciesBasisData] = load_from_pyscf(list(spe_set), qmbasis)
+    basis_data: dict[str, SpeciesBasisData] = load_from_pyscf(list(spe_set), qmbasis)
 
     """write to the database"""
     if dryrun:
@@ -36,7 +34,7 @@ def build(dryrun: bool = False, force_overwrite: bool = False):
 
 
 
-def load_from_pyscf(species_list: List[str], qmbasis: str):
+def load_from_pyscf(species_list: list[str], qmbasis: str):
     """load the xxx-jkfit density fitting basis from PySCF
 
     Args:

--- a/salted/pyscf/run_pyscf.py
+++ b/salted/pyscf/run_pyscf.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import sys
 import time
-from typing import List, Tuple, Union
 
 import numpy as np
 from ase.io import read
@@ -12,7 +11,7 @@ from salted.sys_utils import ARGHELP_INDEX_STR, ParseConfig, parse_index_str
 
 
 def run_pyscf(
-    atoms: List,
+    atoms: list,
     basis: str,
     xc: str,
 ):
@@ -22,7 +21,7 @@ def run_pyscf(
     return mf.make_rdm1()
 
 
-def main(geom_indexes: Union[List[int], None], num_threads: int = None):
+def main(geom_indexes: list[int] | None, num_threads: int = None):
     inp = ParseConfig().parse_input()
     geoms_all = read(inp.system.filename, ":")
     if geom_indexes is None:

--- a/salted/rkhs_vector.py
+++ b/salted/rkhs_vector.py
@@ -1,7 +1,6 @@
 import os
 import os.path as osp
 import time
-from typing import Dict, List, Tuple
 import copy
 
 import numpy as np
@@ -160,7 +159,7 @@ def build():
                     power[lam] = p.reshape(natoms[iconf],2*lam+1,featsize)
 
             # Compute kernels and RKHS descriptors 
-            Psi:Dict[Tuple[int, str], np.ndarray] = {}
+            Psi:dict[tuple[int, str], np.ndarray] = {}
             ispe = {}
             Tsize = 0
             for spe in species:
@@ -339,7 +338,7 @@ def build():
                         Psi_cart[(ic,spe,lam)] = np.zeros((natom_dict[(iconf,spe)]*(2*lam+1),Vmat[(lam,spe)].shape[-1]))
 
 
-            Psi:Dict[Tuple[int, str], np.ndarray] = {}
+            Psi:dict[tuple[int, str], np.ndarray] = {}
             ispe = {}
             Tsize = 0
             for spe in species:

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -2,7 +2,7 @@
 import os
 import os.path as osp
 import re
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Literal
 import sys
 
 import h5py
@@ -54,7 +54,7 @@ def build_featomic_hyper_params(rep_cfg) -> dict:
         raise ValueError(f"Unknown representation type '{rep_cfg.type}': must be 'rho' or 'V'.")
 
 
-def read_system(filename: str = None, spelist: List[str] = None, dfbasis: str = None):
+def read_system(filename: str = None, spelist: list[str] = None, dfbasis: str = None):
     """read a geometry file and return the formatted information
 
     Args:
@@ -276,7 +276,7 @@ def distribute_jobs(comm, jobs: list | np.ndarray, root: int = 0) -> list | np.n
     return my_jobs
 
 
-def get_conf_range(rank, size, ntest, testrangetot) -> List[List[int]]:
+def get_conf_range(rank, size, ntest, testrangetot) -> list[list[int]]:
     """
     DEPRECATED: Please use `distribute_jobs` instead.
     This function was used to manually split a range of jobs for MPI scattering.
@@ -353,7 +353,7 @@ ARGHELP_INDEX_STR = """Indexes to calculate, start from 0. Format: 1,3-5,7-10. \
 Default is "all", which means all structures."""
 
 
-def parse_index_str(index_str: Union[str, Literal["all"]]) -> Union[None, Tuple]:
+def parse_index_str(index_str: str | Literal["all"]) -> tuple | None:
     """Parse index string, e.g. "1,3-5,7-10" -> (1,3,4,5,7,8,9,10)
 
     If index_str is "all", return None. (indicating all structures)
@@ -381,11 +381,11 @@ def parse_index_str(index_str: Union[str, Literal["all"]]) -> Union[None, Tuple]
         return tuple(indexes)
 
 
-def format_index_ranges(indexes: Optional[Union[tuple, list, np.ndarray]] = None, verbose=False) -> str:
+def format_index_ranges(indexes: tuple | list | np.ndarray | None = None, verbose=False) -> str:
     """Format a list of indexes into a compact string representation of ranges.
 
     Args:
-        indexes (Optional[Union[tuple, list, np.ndarray]]): Integers to format into ranges.
+        indexes (tuple | list | np.ndarray | None): Integers to format into ranges.
             Duplicates are removed and sorted. Defaults to None.
         verbose (bool): If True, always returns the full range string. If False, returns
             a summary string when result exceeds 80 characters. Defaults to False.
@@ -563,11 +563,11 @@ class ParseConfig:
     In our context, "input file" equals to "confiuration file", refers to the SALTED input file named `inp.yaml`.
     """
 
-    def __init__(self, _dev_inp_fpath: Optional[str] = None):
+    def __init__(self, _dev_inp_fpath: str | None = None):
         """Initialize configuration parser
 
         Args:
-            _dev_inp_fpath (Optional[str], optional): Path to the input file. Defaults to None.
+            _dev_inp_fpath (str | None, optional): Path to the input file. Defaults to None.
                 Don't use this argument, it's for testing only!!!
         """
         if _dev_inp_fpath is None:
@@ -594,7 +594,7 @@ class ParseConfig:
         inp = self.check_input(inp)
         return AttrDict(inp)
 
-    def get_all_params(self) -> Tuple:
+    def get_all_params(self) -> tuple:
         """return all parameters with a tuple
 
         About `sparsify` in the return tuple:
@@ -670,7 +670,7 @@ class ParseConfig:
             HP2,
         )
 
-    def get_all_params_simple1(self) -> Tuple:
+    def get_all_params_simple1(self) -> tuple:
         """return all parameters with a tuple
 
         Please copy & paste:
@@ -717,7 +717,7 @@ class ParseConfig:
             inp.gpr.trainsel,
         )
 
-    def check_input(self, inp: Dict):
+    def check_input(self, inp: dict):
         """Check keys (required, optional, not allowed), and value types and ranges
 
 
@@ -969,7 +969,9 @@ class ParseConfig:
             },
         }
 
-        def rec_apply_default_vals(_inp: Dict, _inp_template: Dict[str, Union[Dict, Tuple]], _prev_key: str):
+        def rec_apply_default_vals(
+            _inp: dict, _inp_template: dict[str, dict | tuple], _prev_key: str
+        ):
             """apply default values if optional parameters are not found"""
 
             """check if the keys in inp exist in inp_template"""
@@ -996,7 +998,7 @@ class ParseConfig:
                     raise ValueError(f"Invalid input template: {val}. Did you changed the template for parsing?")
             return _inp
 
-        def rec_check_vals(_inp: Dict, _inp_template: Dict[str, Union[Dict, Tuple]], _prev_key: str):
+        def rec_check_vals(_inp: dict, _inp_template: dict[str, dict | tuple], _prev_key: str):
             """check values' type and range"""
             for key, template in _inp_template.items():
                 if isinstance(template, dict):
@@ -1060,7 +1062,7 @@ class ParseConfig:
         return loader
 
 
-def get_qmcode_checker(qmcode: Union[str, list[str]]) -> callable:
+def get_qmcode_checker(qmcode: str | list[str]) -> callable:
     """Factory that returns a checker function for a specific qmcode"""
     if isinstance(qmcode, str):
         qmcode = [qmcode]
@@ -1122,11 +1124,11 @@ def test_inp():
 class Irreps(tuple):
     """Handle irreducible representation arrays, like slices, multiplicities, etc."""
 
-    def __new__(cls, irreps: Union[str, List[int], Tuple[int]]) -> "Irreps":
+    def __new__(cls, irreps: str | list[int] | tuple[int]) -> "Irreps":
         """Create an Irreps object
 
         Args:
-            irreps (Union[str, List[int], Tuple[int]]): irreps info
+            irreps (str | list[int] | tuple[int]): irreps info
                 - str, e.g. `1x0+2x1+3x2+3x3+2x4+1x5`
                     - multiplicities and l values joined by `x`
                 - Tuple[Tuple[int]], e.g. ((1, 0), (2, 1), (3, 2), (3, 3), (2, 4), (1, 5),)
@@ -1161,7 +1163,7 @@ class Irreps(tuple):
                     f"Invalid irreps format: {irreps}"
                 )
                 this_l_cnt, this_l = 1, irreps[0]
-                mul_l_list: List[Tuple[int]] = []
+                mul_l_list: list[tuple[int, int]] = []
                 for l in irreps[1:]:
                     if l == this_l:
                         this_l_cnt += 1
@@ -1187,7 +1189,7 @@ class Irreps(tuple):
         return sum(mul for mul, _ in self)
 
     @property
-    def ls(self) -> List[int]:
+    def ls(self) -> tuple[int, ...]:
         """list of l values in the irreps"""
         return tuple(l for mul, l in self for _ in range(mul))
 
@@ -1202,7 +1204,7 @@ class Irreps(tuple):
     def __add__(self, other: "Irreps") -> "Irreps":
         return Irreps(super().__add__(other))
 
-    def slices(self) -> List[slice]:
+    def slices(self) -> tuple[slice, ...]:
         """return all the slices for each l"""
         if hasattr(self, "_slices"):
             return self._slices
@@ -1218,7 +1220,7 @@ class Irreps(tuple):
             self._slices = tuple(self._slices)
         return self._slices
 
-    def slices_l(self, l: int) -> List[slice]:
+    def slices_l(self, l: int) -> tuple[slice, ...]:
         """return all the slices for a specific l"""
         return tuple(sl for _l, sl in zip(self.ls, self.slices()) if l == _l)
 


### PR DESCRIPTION
# Summary
This PR addresses issue #79 by modernizing type hints across the codebase and docs using Python 3.10+ syntax.

Please close #79 when merged.

## What changed
- Replaced legacy typing aliases such as List, Dict, Tuple, Optional, and Union with modern forms.
- Migrated to built-in generics such as list[...] and dict[...].
- Replaced Union[X, Y] with X | Y and Optional[X] with X | None.
- Kept typing constructs that still have no built-in replacement, such as Literal, TypeVar, and Protocol, where needed.
- Updated documentation examples to match modern annotation style, including input schema/type descriptions.

## Behavior and compatibility
- This is a non-functional maintenance change.
- Runtime behavior and scientific logic are unchanged.
- Type annotations now assume Python 3.10+ syntax support.

## Tests
- Confirmed that updated annotations are syntactically valid under the target interpreter policy (Python 3.10+).
- Confirmed no intended logic changes in execution paths.
- Tested on water monomer testcase with FHI-aims, works well.

## Update
Also included doc update on CP2K water monomer.