### PR TITLE
Constructing Hessian matrices with numba

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,11 @@ References
 
 Installation
 ------------
-In the SALTED directory, simply run :code:`make`, followed by :code:`pip install .`
-   
+In the SALTED directory, simply run :code:`pip install .`
+
+Optionally, Fortran extensions (f2py) can be compiled by running :code:`make` before installing.
+These are no longer required and Hessian construction uses Numba instead.
+
 Dependencies
 ------------
 
@@ -44,7 +47,7 @@ A parallel h5py installation is required to use MPI parellelisation. This can be
 :code:`HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py`
 provided HDF5 has been compiled with MPI support.
 
---> :code:`pip install meson ninja` to run f2py using meson backend following versions of Python >= 3.12.
+--> (Optional) :code:`pip install meson ninja`, only needed if compiling f2py extensions via :code:`make`.
 
 Input file
 ----------

--- a/docs/input.md
+++ b/docs/input.md
@@ -86,7 +86,7 @@ Remember to set `inp.predict` if one wants to predict densities.
 | `gradtol` | `float` | `1e-5` | Minimum gradient norm tolerance for CG minimization. |
 | `restart` | `bool` | `False` | Whether to restart from previous minimization checkpoint. |
 | `trainsel` | `Literal["sequential"] \| Literal["random"]` | `"random"` | Select the training set at random or sequentially from the entire dataset. |
-| `sparse_algorithm` | `Literal["dense"] \| Literal["omp_sparse"]` | `"omp_sparse"` | The algorithm to compute Hessian matrices, if making use of the RKHS vector sparsity. |
+| `sparse_algorithm` | `Literal["dense"] \| Literal["numba"] \| Literal["omp_sparse"]` | `"numba"` | The algorithm to compute Hessian matrices using RKHS vector sparsity. `"numba"` uses JIT-compiled kernels (default). `"omp_sparse"` uses OpenMP Fortran extensions (requires `make`; falls back to `"numba"` if unavailable). `"dense"` disables sparse operations. |
 
 ---
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -88,6 +88,12 @@ Remember to set `inp.predict` if one wants to predict densities.
 | `trainsel` | `Literal["sequential"] \| Literal["random"]` | `"random"` | Select the training set at random or sequentially from the entire dataset. |
 | `sparse_algorithm` | `Literal["dense"] \| Literal["numba"] \| Literal["omp_sparse"]` | `"numba"` | The algorithm to compute Hessian matrices using RKHS vector sparsity. `"numba"` uses JIT-compiled kernels (default). `"omp_sparse"` uses OpenMP Fortran extensions (requires `make`; falls back to `"numba"` if unavailable). `"dense"` disables sparse operations. |
 
+!!! note "Tuning the Numba cache budget for Hessian computation"
+    When `sparse_algorithm: numba` is used, the L3 cache budget can be controlled via the environment variable `SALTED_NUMBA_CACHE_BYTES` (default: 32 MiB). For MPI runs, set it to approximately `total_L3 / ranks_per_node / 2`:
+    ```bash
+    export SALTED_NUMBA_CACHE_BYTES=$(( 512*1024*1024 / 16 / 2 ))  # 512 MiB L3, 16 ranks/node
+    ```
+
 ---
 
 ## API

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,9 @@
 
 ## Install SALTED
 
-You can find the SALTED program on [GitHub](https://github.com/andreagrisafi/SALTED). In the SALTED directory, simply run `make`, followed by `pip install .`
+You can find the SALTED program on [GitHub](https://github.com/andreagrisafi/SALTED). In the SALTED directory, simply run `pip install .`
+
+Optionally, Fortran extensions (f2py) can be compiled by running `make` before installing. These are no longer required and Hessian construction uses Numba instead.
 
 ??? note "Editable python package"
     If you want to modify the code, you can install SALTED with the following command:
@@ -24,7 +26,7 @@ You can find the SALTED program on [GitHub](https://github.com/andreagrisafi/SAL
 
  - `mpi4py`: mpi4py is required to use MPI parallelisation; SALTED can nonetheless be run without this. A parallel h5py installation is required to use MPI parellelisation. This can be installed by running: `HDF5_MPI="ON" CC=mpicc pip install --no-cache-dir --no-binary=h5py h5py` provided HDF5 has been compiled with MPI support.
 
- - `pip install meson ninja` to run f2py using meson backend following versions of Python > 3.12.
+ - (Optional) `pip install meson ninja`, only needed if compiling f2py extensions via `make`.
 
 ## Install electronic-structure codes 
 

--- a/salted/hessian_matrix.py
+++ b/salted/hessian_matrix.py
@@ -106,7 +106,7 @@ def _compute_sparse_operations(psivec, ref_projs, over, sparse_algorithm):
         psivec: Sparse matrix (scipy.sparse)
         ref_projs: Dense vector/matrix
         over: Dense overlap matrix
-        sparse_algorithm: "omp_sparse" or "dense"
+        sparse_algorithm: "numba", "dense", or "omp_sparse"
 
     Returns:
         (avec_contrib, bmat_contrib, algorithm_used)
@@ -124,10 +124,10 @@ def _compute_sparse_operations(psivec, ref_projs, over, sparse_algorithm):
             return avec_contrib, bmat_contrib, "omp_sparse"
 
         except Exception as e:
-            print(f"Warning: OpenMP sparse operations failed ({e}), falling back to dense")
-            # Fall through to dense computation
+            print(f"Warning: omp_sparse unavailable ({e}), falling back to numba", flush=True)
+            sparse_algorithm = "numba"
 
-    elif sparse_algorithm == "numba":
+    if sparse_algorithm == "numba":
         from salted.numba_sparse import get_hessian_engine
         N_df, K_rkhs = psivec.shape
         avec_contrib = psivec.T @ ref_projs               # O(nnz) vector multiply

--- a/salted/hessian_matrix.py
+++ b/salted/hessian_matrix.py
@@ -127,6 +127,14 @@ def _compute_sparse_operations(psivec, ref_projs, over, sparse_algorithm):
             print(f"Warning: OpenMP sparse operations failed ({e}), falling back to dense")
             # Fall through to dense computation
 
+    elif sparse_algorithm == "numba":
+        from salted.numba_sparse import get_hessian_engine
+        N_df, K_rkhs = psivec.shape
+        avec_contrib = psivec.T @ ref_projs               # O(nnz) vector multiply
+        engine       = get_hessian_engine(N_df, K_rkhs)
+        bmat_contrib = engine.compute(over, psivec).copy()
+        return avec_contrib, bmat_contrib, "numba"
+
     # Dense fallback (original behavior)
     psi_dense = psivec.toarray()
     avec_contrib = np.dot(psi_dense.T, ref_projs)

--- a/salted/numba_sparse.py
+++ b/salted/numba_sparse.py
@@ -1,0 +1,175 @@
+"""
+Numba JIT kernel for dense @ CSC sparse matrix multiplication, used to
+accelerate the Hessian H = Psi^T @ S @ Psi in hessian_matrix.py.
+
+Only the K-blocked variant is exposed here; it is strictly better than the
+plain column-parallel kernel for the matrix sizes encountered in SALTED
+(N_df up to ~17000, where AT = S.T can reach several GB).
+
+Public API:
+    get_hessian_engine(N_df, K_rkhs) -> KBlockedHessianEngine
+        Returns a cached engine for the given shape.
+        Cache budget is read from SALTED_NUMBA_CACHE_BYTES (default 32 MiB).
+"""
+
+import os
+import re
+import subprocess
+
+import numpy as np
+import scipy.sparse
+from numba import njit, prange
+
+
+# ---------------------------------------------------------------------------
+# Cache-size detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_cache_bytes():
+    """L3 byte budget for the AT k-block.
+
+    Resolution order:
+      1. SALTED_NUMBA_CACHE_BYTES env var  (use for MPI: set per-rank budget)
+      2. lscpu L3 / 2
+      3. 32 MiB fallback
+    """
+    env_val = os.environ.get("SALTED_NUMBA_CACHE_BYTES")
+    if env_val:
+        return int(env_val)
+    try:
+        out = subprocess.check_output(["lscpu"], text=True)
+        m = re.search(r"L3 cache:\s+([\d.]+)\s*([KMG])i?B", out, re.IGNORECASE)
+        if m:
+            val = float(m.group(1))
+            unit = m.group(2).upper()
+            l3 = int(val * {"K": 1024, "M": 1024**2, "G": 1024**3}[unit])
+            return l3 // 2
+    except Exception:
+        pass
+    return 32 * 1024 * 1024
+
+
+def _auto_bk(M, cache_bytes, itemsize=8):
+    """Rows of AT per k-block given a byte budget."""
+    return max(64, cache_bytes // max(1, int(M) * itemsize))
+
+
+# ---------------------------------------------------------------------------
+# K-blocked column-parallel kernel
+# ---------------------------------------------------------------------------
+
+
+@njit(parallel=True, fastmath=True, cache=True)
+def _dense_csc_kernel_kblocked(dense_T, indptr, indices, data, result_T, B_k):
+    # dense_T : (K, M) C-order
+    # result_T: (N, M) C-order, pre-zeroed by caller
+    N, M = result_T.shape
+    K = dense_T.shape[0]
+    n_kblocks = (K + B_k - 1) // B_k
+    for kb in range(n_kblocks):  # serial
+        k0 = kb * B_k
+        k1 = min(k0 + B_k, K)
+        for j in prange(N):  # parallel over columns
+            col_lo = indptr[j]
+            col_hi = indptr[j + 1]
+            lo, hi = col_lo, col_hi
+            # below is optimized, using bisect search
+            while lo < hi:
+                mid = (lo + hi) >> 1
+                if indices[mid] < k0:
+                    lo = mid + 1
+                else:
+                    hi = mid
+            ptr_lo = lo
+            lo, hi = ptr_lo, col_hi
+            while lo < hi:
+                mid = (lo + hi) >> 1
+                if indices[mid] < k1:
+                    lo = mid + 1
+                else:
+                    hi = mid
+            ptr_hi = lo
+            for ptr in range(ptr_lo, ptr_hi):
+                k = indices[ptr]
+                val = data[ptr]
+                for i in range(M):
+                    result_T[j, i] += dense_T[k, i] * val
+
+
+# ---------------------------------------------------------------------------
+# Engine: pre-allocated buffers + two-step Hessian
+# ---------------------------------------------------------------------------
+
+
+class KBlockedHessianEngine:
+    """
+    H = Psi^T @ S @ Psi via two K-blocked SpMM calls.
+
+    Pre-allocates all buffers for the given (N_df, K_rkhs) shape.
+    Call warmup() once before the first timed/MPI use to trigger JIT compilation.
+    """
+
+    def __init__(self, N_df, K_rkhs, cache_bytes=None):
+        cb = cache_bytes if cache_bytes is not None else _detect_cache_bytes()
+        itemsize = 8  # float64
+        self.R_storage = np.empty((K_rkhs, N_df), dtype=np.float64)
+        self._R_buf = np.empty((N_df, K_rkhs), dtype=np.float64)
+        self.H = np.empty((K_rkhs, K_rkhs), dtype=np.float64)
+        self._B_k1 = int(_auto_bk(N_df, cb, itemsize))  # step 1: rows of S
+        self._B_k2 = int(_auto_bk(K_rkhs, cb, itemsize))  # step 2: rows of R
+
+    def compute(self, S, Psi_csc):
+        """Return H = Psi^T @ S @ Psi, shape [K_rkhs, K_rkhs].
+
+        Returns a view into an internal buffer; call .copy() if you need to own it.
+        """
+        if not scipy.sparse.issparse(Psi_csc):
+            raise TypeError("Psi_csc must be a scipy sparse matrix")
+        sp = Psi_csc if isinstance(Psi_csc, scipy.sparse.csc_matrix) else Psi_csc.tocsc()
+        indptr = np.ascontiguousarray(sp.indptr, dtype=np.int32)
+        indices = np.ascontiguousarray(sp.indices, dtype=np.int32)
+        data = np.ascontiguousarray(sp.data, dtype=np.float64)
+        S_c = np.ascontiguousarray(S, dtype=np.float64)
+
+        # Step 1: R^T = Psi^T @ S (S is symmetric → pass S directly as dense_T)
+        self.R_storage[:] = 0.0
+        _dense_csc_kernel_kblocked(S_c, indptr, indices, data, self.R_storage, self._B_k1)
+
+        # Step 2: H = Psi^T @ R (R_storage.T is strided → copy required)
+        np.copyto(self._R_buf, self.R_storage.T)
+        self.H[:] = 0.0
+        _dense_csc_kernel_kblocked(self._R_buf, indptr, indices, data, self.H, self._B_k2)
+        return self.H  # H is symmetric
+
+    @staticmethod
+    def warmup():
+        """Trigger JIT compilation with a zero-work dummy call."""
+        iptr = np.zeros(2, np.int32)
+        idx = np.zeros(1, np.int32)
+        dat = np.zeros(1, np.float64)
+        buf = np.zeros((1, 1), np.float64)
+        _dense_csc_kernel_kblocked(np.zeros((1, 1)), iptr, idx, dat, buf, 1)
+
+
+# ---------------------------------------------------------------------------
+# Module-level engine cache
+# ---------------------------------------------------------------------------
+
+_engines: dict = {}
+
+
+def get_hessian_engine(N_df, K_rkhs):
+    """Return a cached KBlockedHessianEngine for the given shape.
+
+    JIT-compiles on first call (once per process).
+    Cache budget read from SALTED_NUMBA_CACHE_BYTES env var (default 32 MiB).
+    For MPI jobs set: export SALTED_NUMBA_CACHE_BYTES=$(( L3_bytes / ranks_per_node / 2 ))
+    """
+    key = (N_df, K_rkhs)
+    if key not in _engines:
+        cache_bytes = _detect_cache_bytes()
+        eng = KBlockedHessianEngine(N_df, K_rkhs, cache_bytes=cache_bytes)
+        KBlockedHessianEngine.warmup()
+        _engines[key] = eng
+    return _engines[key]

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -964,7 +964,7 @@ class ParseConfig:
                     False,
                     "omp_sparse",
                     str,
-                    lambda inp, val: val in ("dense", "omp_sparse"),
+                    lambda inp, val: val in ("dense", "omp_sparse", "numba"),
                 ),
             },
         }

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -962,7 +962,7 @@ class ParseConfig:
                 ),  # if shuffle the training set
                 "sparse_algorithm": (
                     False,
-                    "omp_sparse",
+                    "numba",
                     str,
                     lambda inp, val: val in ("dense", "omp_sparse", "numba"),
                 ),


### PR DESCRIPTION
# Numba-accelerated SpMM kernel for SALTED Hessian construction

**TL;DR**: Adds a Numba JIT kernel (`numba_sparse.py`) as a drop-in replacement for the Fortran/OpenMP f2py Hessian kernel. No Fortran compiler needed. `inp.gpr.sparse_algorithm` now defaults to `"numba"`; `"omp_sparse"` remains available but falls back to `"numba"` if the `.so` is absent. `pip install .` now works without running `make` first.

## Background

SALTED constructs a Hessian matrix $H = \Psi^\top S \Psi$ for each structure in the training dataset, where $\Psi$ is a sparse RKHS feature matrix (CSC format, shape `[N_df, K_rkhs]`) and $S$ is the dense symmetric DF-basis overlap matrix (shape `[N_df, N_df]`). For large systems ($N_\text{df}$ up to ~17 000, $K_\text{rkhs}$ up to ~60 000) this becomes the dominant cost. The existing implementation uses a Fortran+OpenMP kernel wrapped via f2py; this PR provides a drop-in Python replacement using Numba JIT — no Fortran compiler needed on compute nodes.

---

## Operation and decomposition

The full Hessian is computed in two sparse matrix-multiply (SpMM) steps:

$$
\underbrace{R}_{\scriptscriptstyle[N_\text{df},\,K_\text{rkhs}]} = S \Psi
\qquad\longrightarrow\qquad
\underbrace{H}_{\scriptscriptstyle[K_\text{rkhs},\,K_\text{rkhs}]} = \Psi^\top R
$$

Each step has the form **dense `[M, K]` @ sparse-CSC `[K, N]`**, implemented by the kernel below.

---

## Kernel algorithm

### Base kernel — `numba_col` (and `f2py`)

Both `f2py` (Fortran+OpenMP) and `numba_col` (Python+Numba) implement the same algorithm.
The key trick is transposing `dense` to `[K, M]` row-major so the inner AXPY loop is stride-1 and LLVM/gfortran can emit AVX-512 FMA instructions.

```
# dense [M, K] @ sparse-CSC [K, N]  →  result [M, N]

AT       = dense.T.copy()      # [K, M] row-major; AT[k, :] is stride-1
result_T = zeros(N, M)         # [N, M], pre-zeroed; result_T[j, :] is stride-1

parallel for j in 0 .. N:          # each thread owns one full row of result_T
    for ptr in indptr[j] .. indptr[j+1]:
        k   = indices[ptr]
        val = data[ptr]
        result_T[j, :] += AT[k, :] * val   # stride-1 AXPY → SIMD ✓

result = result_T.T            # free view, no copy
```

Symmetry shortcut for Step 1: $S$ is symmetric so $S^\top = S$; `AT = S` directly, no copy.

### K-blocked variant — `numba_col_kblock`

For large datasets, `AT = dense.T` can reach 1–2 GB (TiS2: 1.19 GB, ZrS2: 2.22 GB). Each non-zero in the sparse matrix causes a thread to read one row of `AT`. With many threads all reading different rows, the working set exceeds L3 and threads compete for DRAM bandwidth — scaling stalls.

**Fix:** tile the $K$ dimension into blocks of $B_k$ rows that fit in L3. The block is shared read-only across all threads, so DRAM bandwidth scales with thread count.

```
AT       = dense.T.copy()      # [K, M]
result_T = zeros(N, M)         # [N, M], pre-zeroed
B_k      = cache_bytes // (M * 8)   # rows of AT per block, tuned to L3 budget

for kb in 0 .. ceil(K / B_k):      # serial outer loop over K-blocks
    k0, k1 = kb*B_k, min((kb+1)*B_k, K)
    # AT[k0:k1, :] is now L3-resident and shared across all threads

    parallel for j in 0 .. N:
        # binary-search for non-zeros with k in [k0, k1)
        ptr_lo = bisect_left(indices, k0, indptr[j],   indptr[j+1])
        ptr_hi = bisect_left(indices, k1, ptr_lo,      indptr[j+1])
        for ptr in ptr_lo .. ptr_hi:
            k   = indices[ptr]
            val = data[ptr]
            result_T[j, :] += AT[k, :] * val

result = result_T.T
```

$B_k$ is computed automatically from the L3 budget. With MPI, set the budget to `total_L3 / n_ranks_per_node / 2` (see tuning section below).

---

## Datasets

Benchmarks run on **AMD EPYC 9554** (2 × 64 cores, 256 HW threads, 512 MiB L3 in 16 × 32 MiB instances), numba 0.65.1, Python 3.11.
Note that $N_\text{df}$ corresponds to the matrix dimension of $K$ above, and $K_\text{rkhs}$ to $N$.

| Dataset  | $N_\text{df}$ | $K_\text{rkhs}$ | nnz        | density | AT size (Step 1) |
|----------|---------------|-----------------|------------|---------|------------------|
| water    | 418           | 7 117           | 42 986     | 1.4%    | 1.4 MB           |
| graphene | 3 096         | 17 200          | 3 168 000  | 5.9%    | 73 MB            |
| TiS2     | 12 510        | 44 878          | 9 726 372  | 1.7%    | 1.19 GB          |
| ZrS2     | 17 064        | 59 560          | 11 893 860 | 1.2%    | 2.22 GB          |

---

## Results

### Figure 1 — Thread scaling: all three methods

<img width="1631" height="2354" alt="timing_all" src="https://github.com/user-attachments/assets/3b89e951-b5a0-49f8-8199-237e0f815f48" />

**Left column**: $S @ \Psi$ (single SpMM). **Right column**: full Hessian $H = \Psi^\top S \Psi$.
Each row is one dataset (water → ZrS2, smallest to largest).

**Conclusions:**
- **f2py** scales well with thread count across all datasets and both operations (till around $2^5$ threads) except water.
- **`numba_col` breaks down for large dense matrices.** The problem is visible in the graphene rows: for $S@\Psi$ (AT ≈ 73 MB, fits in L3) `numba_col` scales comparably to f2py, but for the Hessian (Step 2 uses $R^\top$ as the dense input, shape `[N_\text{df}, K_\text{rkhs}]` ≈ 387 MB for graphene) scaling collapses. For TiS2 and ZrS2 the problem is even more severe. The root cause is L3 thrashing: threads evict each other's `AT` rows, and all bandwidth goes   to DRAM rather than useful compute.
- **`numba_col_kblock` restores scaling** for TiS2 and ZrS2, matching or beating f2py,   by keeping one $B_k \times M$ slice of AT L3-resident for the duration of each parallel sweep.

---

### Figure 2 — K-block cache budget vs. wall time (8 threads)

<img width="1483" height="1472" alt="kblock_timing_vs_cache" src="https://github.com/user-attachments/assets/11157a46-8679-4764-939d-e733a22cccad" />

Each curve is one cache budget $B_k$ (from 16 MiB to 512 MiB); x-axis is thread count
(same 8-thread slice for all curves shown here).

**Conclusions:**
- **water** is unaffected by cache size — its AT is only 1.4 MB and always fits in L3.
- **Optimal budget grows with dataset size**: graphene is satisfied by a small budget; TiS2 and ZrS2 need a larger budget to suppress DRAM pressure.
- **128 MiB looks optimal in single-rank runs**, but this is a misleading upper bound. On the EPYC 9554, each 32 MiB L3 instance is shared by 8 physical cores. In a typical MPI job with one rank per NUMA domain (8 cores/rank), the safe budget is at most 32 MiB. Using a larger budget causes ranks to evict each other's blocks.
- **Recommended default: 32 MiB per MPI rank.** This matches one full L3 instance and works well across all tested datasets.

---

### Figure 3 — Full reference: `numba_col_kblock` across all cache budgets and thread counts

<img width="1834" height="2354" alt="kblock_timing_all" src="https://github.com/user-attachments/assets/d659f571-0b5e-4693-a4b8-b99e855fa6d0" />

Thread-scaling curves for `numba_col_kblock` at every tested cache budget, for all four datasets. Included as a complete reference for selecting the cache budget for a given system and dataset.

---

### Figure 4 — SVD Hessian matrices

<img width="1800" height="900" alt="fig_sigvals_zoom" src="https://github.com/user-attachments/assets/91bd91d3-0018-496e-a87e-b808d5ed3d2f" />
<img width="1800" height="900" alt="fig_sigvals" src="https://github.com/user-attachments/assets/27895a7d-4e9d-47c9-b7ca-3cc55e46e161" />

Accuracy check is based on comparing singular values for water and graphene. Within the range between $10^{-14}$ to the largest singular value, the sparse results (`numba_col_kblock`) agree well with those from dense method.
Accordingly, it is safe to use $\eta$ as small as $10^{-14}$, and for even smaller values.

---

## SALTED integration

Three minimal changes integrate `numba_col_kblock` into SALTED as `sparse_algorithm: numba`.

### 1. `salted/numba_sparse.py` (new file)

Contains `_dense_csc_kernel_kblocked`, `KBlockedHessianEngine`, and a module-level engine cache. The `get_hessian_engine(N_df, K_rkhs)` factory returns a cached engine, allocating buffers and JIT-compiling on the first call:

```python
_engines: dict = {}

def get_hessian_engine(N_df, K_rkhs):
    key = (N_df, K_rkhs)
    if key not in _engines:
        cache_bytes = _detect_cache_bytes()   # reads SALTED_NUMBA_CACHE_BYTES or lscpu
        eng = KBlockedHessianEngine(N_df, K_rkhs, cache_bytes=cache_bytes)
        KBlockedHessianEngine.warmup()        # trigger JIT once per process
        _engines[key] = eng
    return _engines[key]
```

`(N_df, K_rkhs)` is constant within a training run (same system, same basis), so the engine is created exactly once.

### 2. `salted/sys_utils.py` — one-line change

The default for `sparse_algorithm` is changed from `"omp_sparse"` to `"numba"`, so new users get the Numba path without any config change.

```python
# before
lambda inp, val: val in ("dense", "omp_sparse"),
# after
lambda inp, val: val in ("dense", "omp_sparse", "numba"),
```

### 3. `salted/hessian_matrix.py` — new `elif` branch in `_compute_sparse_operations`

`omp_sparse` is still accepted as a value. If the Fortran extension (`salted/lib/omp_sparse.so`) is unavailable, it now falls back to `"numba"` rather than `"dense"`, with a printed warning. The fallback chain is: `omp_sparse → numba → dense`.

```python
elif sparse_algorithm == "numba":
    from salted.numba_sparse import get_hessian_engine
    N_df, K_rkhs = psivec.shape
    avec_contrib = psivec.T @ ref_projs               # O(nnz) vector multiply
    engine       = get_hessian_engine(N_df, K_rkhs)
    bmat_contrib = engine.compute(over, psivec).copy()
    return avec_contrib, bmat_contrib, "numba"
```

`Avec` (`psivec.T @ ref_projs`) is a cheap $O(\text{nnz})$ sparse-vector multiply and stays with scipy. Only `Bmat` ($H = \Psi^\top S \Psi$, the expensive part) uses the numba kernel.

### 4. `f2py` installation legacy

To be compatible with `package_data={"salted": ["salted/lib/*.so"]}` in `setup.py` while `make` is no longer required, an empty file `salted/lib/__init__.py` is created.
This dir will be removed when resolving Issue #93 .

### 5. Documentations

Updated `README.rst`, plus `installation.md` and `input.md` in `docs/`

### Usage in `input.yaml`

```yaml
gpr:
  sparse_algorithm: numba
```

### Cache budget tuning

The L3 budget for each K-block is **not** in `input.yaml` — it is a machine-level parameter (like `OMP_NUM_THREADS`), not a physics parameter. Set it in the job script:

```bash
# Single MPI rank — use half the total L3
export SALTED_NUMBA_CACHE_BYTES=$(( 256 * 1024 * 1024 ))

# Multiple MPI ranks sharing one node — partition the L3 per rank
# Example: 512 MiB total L3, 16 ranks → 16 MiB each
export SALTED_NUMBA_CACHE_BYTES=$(( 512 * 1024 * 1024 / N_RANKS_PER_NODE / 2 ))
```

Default (if unset): `32 MiB`, which fits one L3 instance on the EPYC 9554 and is safe for typical MPI layouts (1 rank per NUMA domain = 8 physical cores).

---

## Benchmarks

- Passed the water monomer test.
- Tested on displaced bilayer ZrS2 with default cache settings, results as below: regression weights obtained from sparse match well with dense; acceleration ~x5 compared to dense method, and ~25% compared to `omp_sparse` based on f2py. Machine: 10 MPI tasks x 12 physical cores each.

<img width="1200" height="1200" alt="weights_compare" src="https://github.com/user-attachments/assets/7bf1bb6a-9493-4395-9d67-f625d9749e59" />

<img width="2700" height="900" alt="times_compare" src="https://github.com/user-attachments/assets/5e1e5c45-702c-4926-a059-db1259de92d1" />


