### PR TITLE
Remove allreduce in salted_prediction

### DIFF
--- a/example/water_monomer_PySCF/test_gradient.py
+++ b/example/water_monomer_PySCF/test_gradient.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 
 inp = ParseConfig().parse_input()
 
-comm, size, rank, _ = detect_mpi()
+comm, size, rank, parallel = detect_mpi()
 
 # Initialize SALTED prediction
 lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals = init_pred.build(rank)
@@ -41,6 +41,9 @@ grad_finite_diff = {}
 # Analytical gradient
 output = salted_prediction.build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,True,structure) 
 grad_pred_coefs = output[1]
+if parallel:
+    comm.Barrier()
+    grad_pred_coefs = comm.allreduce(grad_pred_coefs)
 
 # Compute gradient by finite-differences for each atomic displacement d
 for i in range(len(d)):
@@ -49,11 +52,17 @@ for i in range(len(d)):
     structure.positions[iat,d_c] += d[i]
     output = salted_prediction.build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,False,structure)
     coefs[str(d[i])] = output[0].copy()
+    if parallel:
+        comm.Barrier()
+        coefs[str(d[i])] = comm.allreduce(coefs[str(d[i])])
 
     # -d 
     structure.positions[iat,d_c] -= 2*d[i]
     output = salted_prediction.build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,False,structure)
     coefs[str("m"+str(d[i]))] = output[0].copy()
+    if parallel:
+        comm.Barrier()
+        coefs["m"+str(d[i])] = comm.allreduce(coefs["m"+str(d[i])])
     
     # Compute gradient
     grad_finite_diff[str(d[i])] = (np.array(coefs[str(d[i])]) - np.array(coefs[str("m"+str(d[i]))]))/(2*d[i])

--- a/example/water_monomer_PySCF/test_prediction.py
+++ b/example/water_monomer_PySCF/test_prediction.py
@@ -9,7 +9,7 @@ from salted import salted_prediction
 from salted.sys_utils import ParseConfig, detect_mpi
 inp = ParseConfig().parse_input()
 
-comm, size, rank, _ = detect_mpi()
+comm, size, rank, parallel = detect_mpi()
 
 (saltedname, saltedpath, saltedtype,
 filename, species, average,
@@ -36,7 +36,10 @@ gradient=False
 frames = read(inp.prediction.filename,":")
 for i in range(len(frames)):
     structure = frames[i]
-    [coefs] = salted_prediction.build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,gradient,structure) 
+    [coefs] = salted_prediction.build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,gradient,structure)
+    if parallel:
+        comm.Barrier()
+        coefs = comm.allreduce(coefs)
     if rank==0:
         ref_coefs = np.loadtxt(dirpath+"/COEFFS-"+str(Ntrain+i+1)+".dat")
         print("Conf", i+1, "Consistent prediction?", np.allclose(coefs,ref_coefs)) 

--- a/salted/aims/get_df_err.py
+++ b/salted/aims/get_df_err.py
@@ -13,7 +13,7 @@ from salted.sys_utils import ParseConfig, read_system, sort_grid_data
 
 def main():
     inp = ParseConfig().parse_input()
-    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
     start_time = time.time()
 

--- a/salted/aims/get_ml_err.py
+++ b/salted/aims/get_ml_err.py
@@ -11,7 +11,7 @@ from salted.sys_utils import ParseConfig, read_system, sort_grid_data
 def main():
     # load prediction dataset
     inp = ParseConfig().parse_input()
-    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system(
+    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system(
         filename = inp.prediction.filename,
         spelist = inp.system.species,
         dfbasis = inp.qm.dfbasis,

--- a/salted/aims/move_data_in.py
+++ b/salted/aims/move_data_in.py
@@ -13,7 +13,7 @@ def build():
     
     if rank == 0: print("WARNING! This script assumes you will use an AIMS version >= 240403 to read the predicted RI coefficients. If this is not true, please use move_data_in_reorder instead.")
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system(filename=inp.prediction.filename,spelist = inp.system.species, dfbasis = inp.qm.dfbasis)
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system(filename=inp.prediction.filename,spelist = inp.system.species, dfbasis = inp.qm.dfbasis)
     
     pdir = f"predictions_{inp.salted.saltedname}_{inp.prediction.predname}"
     

--- a/salted/aims/move_data_in_reorder.py
+++ b/salted/aims/move_data_in_reorder.py
@@ -12,7 +12,7 @@ def build():
     comm, size, rank, parallel = detect_mpi()
 
     
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     
     pdir = f"predictions_{inp.salted.saltedname}_{inp.prediction.predname}"
     

--- a/salted/cp2k/extract_basis.py
+++ b/salted/cp2k/extract_basis.py
@@ -6,7 +6,7 @@ from ase.io import read
 import copy
 import time
 
-from salted.sys_utils import ParseConfig, read_system, get_atom_idx
+from salted.sys_utils import ParseConfig
 
 inp = ParseConfig().parse_input()
 

--- a/salted/cp2k/polarizability.py
+++ b/salted/cp2k/polarizability.py
@@ -25,7 +25,7 @@ def build(iconf,ref_coefs):
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
     gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
     if qmcode=="cp2k":
         from ase.io import read

--- a/salted/cp2k/utils.py
+++ b/salted/cp2k/utils.py
@@ -125,7 +125,88 @@ def compute_charge_and_dipole(geom,pseudocharge,natoms,atomic_symbols,lmax,nmax,
 
     return [charge,dipole]
 
-def scale_grad_coefs(geom,pseudocharge,natoms,atomic_symbols,lmax,nmax,species,charge_integrals,coefs,grad_coefs,average,charge):
+def compute_charge_and_dipole_parallelized(geom,pseudocharge,natoms,atoms_range_set,atomic_global_idx,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average,parallel,comm):
+    """Compute total charge and dipole moment for the given configuration"""
+
+    geom.wrap()
+    bohr2angs = 0.529177210670
+    coords = geom.get_positions()/bohr2angs
+    all_symbols = geom.get_chemical_symbols()
+    all_natoms = int(len(all_symbols))
+
+    pseudocharge_dict = {}
+    for i in range(len(species)):
+        pseudocharge_dict[species[i]] = pseudocharge[i] # Warning: species and pseudocharge must have the same ordering
+
+    # Compute unnormalized electron-density integral
+    iaux = 0
+    nele = 0.0
+    charge = 0.0
+    for iat in range(natoms):
+        spe = atomic_symbols[iat]
+        nele += pseudocharge_dict[spe]
+        if iat in atoms_range_set:
+            i = 0
+            for l in range(lmax[spe]+1):
+                for n in range(nmax[(spe,l)]):
+                    if l==0:
+                        charge += charge_integrals[(spe,l,n)] * coefs[iaux+i]
+                    i += 2*l+1
+        for l in range(lmax[spe]+1):
+            for n in range(nmax[(spe,l)]):
+                iaux += 2*l+1
+
+    if parallel:
+        comm.Barrier()
+        charge = comm.allreduce(charge)
+        comm.Barrier()
+
+    # Initialize dipole
+    cart = ["y","z","x"]
+    dipole = {}
+    for icart in range(3):
+        dipole[cart[icart]] = 0.0
+
+    # Perform dipole calculation
+    iaux = 0
+    for iat in range(natoms):
+        if iat in atoms_range_set:
+            spe = all_symbols[atomic_global_idx[iat]]
+            if spe in species:
+                i = 0
+                if average:
+                    # Add contribution of nuclear pseudocharge to the dipole
+                    dipole["x"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],0]
+                    dipole["y"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],1]
+                    dipole["z"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],2]
+                for l in range(lmax[spe]+1):
+                    for n in range(nmax[(spe,l)]):
+                        for im in range(2*l+1):
+                            if l==0:
+                                if average:
+                                    # rescale isotropic coefficients to conserve the electronic charge
+                                    coefs[iaux+i] *= nele/charge
+                                else:
+                                    # remove residual charge from the most diffuse isotropic function
+                                    if n==nmax[(spe,l)]-1:
+                                        coefs[iaux+i] -= charge/(charge_integrals[(spe,l,n)]*natoms)
+                                # Compute l=0 electronic contribution to the dipole
+                                # NB: this is ill-defined in a truly periodic system and/or for systems with a net charge
+                                dipole["x"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,0]
+                                dipole["y"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,1]
+                                dipole["z"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,2]
+                            if l==1:
+                                # Compute l=1 electronic contribution to the dipole
+                                # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates
+                                dipole[cart[im]] -= coefs[iaux+i] * dipole_integrals[(spe,l,n)]
+                            i += 1
+        for l in range(lmax[spe]+1):
+            for n in range(nmax[(spe,l)]):
+                iaux += 2*l+1
+
+    return [charge,dipole]
+
+def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lmax,nmax,species,charge_integrals,coefs,grad_coefs,average,charge,parallel,comm):
     """Compute total charge and dipole moment for the given configuration"""
 
     geom.wrap()
@@ -145,31 +226,49 @@ def scale_grad_coefs(geom,pseudocharge,natoms,atomic_symbols,lmax,nmax,species,c
     for iat in range(natoms):
         spe = atomic_symbols[iat]
         nele += pseudocharge_dict[spe]
+        if iat in atoms_range_set:
+            i=0
+            for l in range(lmax[spe]+1):
+                for n in range(nmax[(spe,l)]):
+                    if l==0:
+                        grad_charge[:,:] += charge_integrals[(spe,l,n)] * grad_coefs[:,:,iaux+i]
+                    i += 2*l+1
         for l in range(lmax[spe]+1):
             for n in range(nmax[(spe,l)]):
-                if l==0:
-                    grad_charge[:,:] += charge_integrals[(spe,l,n)] * grad_coefs[:,:,iaux]
                 iaux += 2*l+1
+
+    #time_red_gc = time.time()
+    if parallel:
+        comm.Barrier()
+        grad_charge = comm.allreduce(grad_charge)
+        comm.Barrier()
+
+    #print(f"Reduce time gc = {(time.time() - time_red_gc):.2f} s", flush=True)
 
     # Perform dipole calculation
     iaux = 0
-    for iat in range(all_natoms):
-        spe = all_symbols[iat]
-        if spe in species:
-            for l in range(lmax[spe]+1):
-                for n in range(nmax[(spe,l)]):
-                    for im in range(2*l+1):
-                        if l==0:
-                            if average:
-                                # rescale isotropic coefficients to conserve the electronic charge
-                                grad_coefs[:,:,iaux] = (grad_coefs[:,:,iaux]*nele/charge)-coefs[iaux]*grad_charge[:,:]/charge
-                            else:
-                                # remove residual charge from the most diffuse isotropic function
-                                if n==nmax[(spe,l)]-1:
-                                    grad_coefs[:,:,iaux] -= grad_charge[:,:]/(charge_integrals[(spe,l,n)]*natoms)
-                        iaux += 1
+    for iat in range(natoms):
+        if iat in atoms_range_set:
+            i = 0
+            spe = atomic_symbols[iat]
+            if spe in species:
+                for l in range(lmax[spe]+1):
+                    for n in range(nmax[(spe,l)]):
+                        for im in range(2*l+1):
+                            if l==0:
+                                if average:
+                                    # rescale isotropic coefficients to conserve the electronic charge
+                                    grad_coefs[:,:,iaux + i] = (grad_coefs[:,:,iaux + i]*nele/charge)-coefs[iaux + i]*grad_charge[:,:]/charge
+                                else:
+                                    # remove residual charge from the most diffuse isotropic function
+                                    if n==nmax[(spe,l)]-1:
+                                        grad_coefs[:,:,iaux + i] -= grad_charge[:,:]/(charge_integrals[(spe,l,n)]*natoms)
+                            i += 1
+        for l in range(lmax[spe]+1):
+            for n in range(nmax[(spe,l)]):
+                iaux += 2*l+1
 
-    return 
+    return
 
 def compute_polarizability(geom,natoms,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs):
     """Compute polarizability tensor for the given configuration"""

--- a/salted/cp2k/utils.py
+++ b/salted/cp2k/utils.py
@@ -125,7 +125,7 @@ def init_moments(inp,species,lmax,nmax,rank):
 #
 #    return [charge,dipole]
 
-def compute_charge_and_dipole(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average,parallel,comm):
+def compute_charge_and_dipole(pseudocharge,natoms,atoms_range_set,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average,parallel,comm):
     """Compute total charge and dipole moment for the given configuration"""
 
     pseudocharge_dict = {}
@@ -204,14 +204,8 @@ def compute_charge_and_dipole(geom,pseudocharge,natoms,atoms_range_set,atomic_sy
 
     return [charge,dipole]
 
-def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lmax,nmax,species,charge_integrals,coefs,grad_coefs,average,charge,parallel,comm):
+def scale_grad_coefs(pseudocharge,natoms,atoms_range_set,atomic_symbols,lmax,nmax,species,charge_integrals,coefs,grad_coefs,average,charge,parallel,comm):
     """Compute total charge and dipole moment for the given configuration"""
-
-    geom.wrap()
-    bohr2angs = 0.529177210670
-    coords = geom.get_positions()/bohr2angs
-    all_symbols = geom.get_chemical_symbols()
-    all_natoms = int(len(all_symbols))
 
     pseudocharge_dict = {}
     for i in range(len(species)):
@@ -245,9 +239,9 @@ def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lma
     # Perform dipole calculation
     iaux = 0
     for iat in range(natoms):
+        spe = atomic_symbols[iat]
         if iat in atoms_range_set:
             i = 0
-            spe = atomic_symbols[iat]
             if spe in species:
                 for l in range(lmax[spe]+1):
                     for n in range(nmax[(spe,l)]):
@@ -267,7 +261,7 @@ def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lma
 
     return
 
-def compute_polarizability(geom,natoms,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs):
+def compute_polarizability(natoms,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs):
     """Compute polarizability tensor for the given configuration"""
 
     # Compute unnormalized response integral

--- a/salted/cp2k/utils.py
+++ b/salted/cp2k/utils.py
@@ -59,80 +59,74 @@ def init_moments(inp,species,lmax,nmax,rank):
 
     return [charge_integrals,dipole_integrals]
 
-def compute_charge_and_dipole(geom,pseudocharge,natoms,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average):
+#def compute_charge_and_dipole(geom,pseudocharge,natoms,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average):
+#    """Compute total charge and dipole moment for the given configuration"""
+#
+#    geom.wrap()
+#    bohr2angs = 0.529177210670
+#    coords = geom.get_positions()/bohr2angs
+#    all_symbols = geom.get_chemical_symbols()
+#    all_natoms = int(len(all_symbols))
+#    
+#    pseudocharge_dict = {}
+#    for i in range(len(species)):
+#        pseudocharge_dict[species[i]] = pseudocharge[i] # Warning: species and pseudocharge must have the same ordering
+#
+#    # Compute unnormalized electron-density integral
+#    iaux = 0
+#    nele = 0.0
+#    charge = 0.0
+#    for iat in range(natoms):
+#        spe = atomic_symbols[iat]
+#        nele += pseudocharge_dict[spe]
+#        for l in range(lmax[spe]+1):
+#            for n in range(nmax[(spe,l)]):
+#                if l==0:
+#                    charge += charge_integrals[(spe,l,n)] * coefs[iaux]
+#                iaux += 2*l+1
+#
+#    # Initialize dipole 
+#    cart = ["y","z","x"]
+#    dipole = {}
+#    for icart in range(3):
+#        dipole[cart[icart]] = 0.0
+#    
+#    # Perform dipole calculation
+#    iaux = 0
+#    for iat in range(all_natoms):
+#        spe = all_symbols[iat]
+#        if spe in species:
+#            if average:
+#                # Add contribution of nuclear pseudocharge to the dipole
+#                dipole["x"] += pseudocharge_dict[spe] * coords[iat,0] 
+#                dipole["y"] += pseudocharge_dict[spe] * coords[iat,1] 
+#                dipole["z"] += pseudocharge_dict[spe] * coords[iat,2] 
+#            for l in range(lmax[spe]+1):
+#                for n in range(nmax[(spe,l)]):
+#                    for im in range(2*l+1):
+#                        if l==0:
+#                            if average:
+#                                # rescale isotropic coefficients to conserve the electronic charge
+#                                coefs[iaux] *= nele/charge
+#                            else:
+#                                # remove residual charge from the most diffuse isotropic function
+#                                if n==nmax[(spe,l)]-1:
+#                                    coefs[iaux] -= charge/(charge_integrals[(spe,l,n)]*natoms)
+#                            # Compute l=0 electronic contribution to the dipole 
+#                            # NB: this is ill-defined in a truly periodic system and/or for systems with a net charge
+#                            dipole["x"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,0]
+#                            dipole["y"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,1]
+#                            dipole["z"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,2]
+#                        if l==1:
+#                            # Compute l=1 electronic contribution to the dipole 
+#                            # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates 
+#                            dipole[cart[im]] -= coefs[iaux] * dipole_integrals[(spe,l,n)]
+#                        iaux += 1
+#
+#    return [charge,dipole]
+
+def compute_charge_and_dipole(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average,parallel,comm):
     """Compute total charge and dipole moment for the given configuration"""
-
-    geom.wrap()
-    bohr2angs = 0.529177210670
-    coords = geom.get_positions()/bohr2angs
-    all_symbols = geom.get_chemical_symbols()
-    all_natoms = int(len(all_symbols))
-    
-    pseudocharge_dict = {}
-    for i in range(len(species)):
-        pseudocharge_dict[species[i]] = pseudocharge[i] # Warning: species and pseudocharge must have the same ordering
-
-    # Compute unnormalized electron-density integral
-    iaux = 0
-    nele = 0.0
-    charge = 0.0
-    for iat in range(natoms):
-        spe = atomic_symbols[iat]
-        nele += pseudocharge_dict[spe]
-        for l in range(lmax[spe]+1):
-            for n in range(nmax[(spe,l)]):
-                if l==0:
-                    charge += charge_integrals[(spe,l,n)] * coefs[iaux]
-                iaux += 2*l+1
-
-    # Initialize dipole 
-    cart = ["y","z","x"]
-    dipole = {}
-    for icart in range(3):
-        dipole[cart[icart]] = 0.0
-    
-    # Perform dipole calculation
-    iaux = 0
-    for iat in range(all_natoms):
-        spe = all_symbols[iat]
-        if spe in species:
-            if average:
-                # Add contribution of nuclear pseudocharge to the dipole
-                dipole["x"] += pseudocharge_dict[spe] * coords[iat,0] 
-                dipole["y"] += pseudocharge_dict[spe] * coords[iat,1] 
-                dipole["z"] += pseudocharge_dict[spe] * coords[iat,2] 
-            for l in range(lmax[spe]+1):
-                for n in range(nmax[(spe,l)]):
-                    for im in range(2*l+1):
-                        if l==0:
-                            if average:
-                                # rescale isotropic coefficients to conserve the electronic charge
-                                coefs[iaux] *= nele/charge
-                            else:
-                                # remove residual charge from the most diffuse isotropic function
-                                if n==nmax[(spe,l)]-1:
-                                    coefs[iaux] -= charge/(charge_integrals[(spe,l,n)]*natoms)
-                            # Compute l=0 electronic contribution to the dipole 
-                            # NB: this is ill-defined in a truly periodic system and/or for systems with a net charge
-                            dipole["x"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,0]
-                            dipole["y"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,1]
-                            dipole["z"] -= coefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,2]
-                        if l==1:
-                            # Compute l=1 electronic contribution to the dipole 
-                            # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates 
-                            dipole[cart[im]] -= coefs[iaux] * dipole_integrals[(spe,l,n)]
-                        iaux += 1
-
-    return [charge,dipole]
-
-def compute_charge_and_dipole_parallelized(geom,pseudocharge,natoms,atoms_range_set,atomic_global_idx,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs,average,parallel,comm):
-    """Compute total charge and dipole moment for the given configuration"""
-
-    geom.wrap()
-    bohr2angs = 0.529177210670
-    coords = geom.get_positions()/bohr2angs
-    all_symbols = geom.get_chemical_symbols()
-    all_natoms = int(len(all_symbols))
 
     pseudocharge_dict = {}
     for i in range(len(species)):
@@ -159,7 +153,6 @@ def compute_charge_and_dipole_parallelized(geom,pseudocharge,natoms,atoms_range_
     if parallel:
         comm.Barrier()
         charge = comm.allreduce(charge)
-        comm.Barrier()
 
     # Initialize dipole
     cart = ["y","z","x"]
@@ -170,39 +163,44 @@ def compute_charge_and_dipole_parallelized(geom,pseudocharge,natoms,atoms_range_
     # Perform dipole calculation
     iaux = 0
     for iat in range(natoms):
+        spe = atomic_symbols[iat]
         if iat in atoms_range_set:
-            spe = all_symbols[atomic_global_idx[iat]]
-            if spe in species:
-                i = 0
-                if average:
-                    # Add contribution of nuclear pseudocharge to the dipole
-                    dipole["x"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],0]
-                    dipole["y"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],1]
-                    dipole["z"] += pseudocharge_dict[spe] * coords[atomic_global_idx[iat],2]
-                for l in range(lmax[spe]+1):
-                    for n in range(nmax[(spe,l)]):
-                        for im in range(2*l+1):
-                            if l==0:
-                                if average:
-                                    # rescale isotropic coefficients to conserve the electronic charge
-                                    coefs[iaux+i] *= nele/charge
-                                else:
-                                    # remove residual charge from the most diffuse isotropic function
-                                    if n==nmax[(spe,l)]-1:
-                                        coefs[iaux+i] -= charge/(charge_integrals[(spe,l,n)]*natoms)
-                                # Compute l=0 electronic contribution to the dipole
-                                # NB: this is ill-defined in a truly periodic system and/or for systems with a net charge
-                                dipole["x"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,0]
-                                dipole["y"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,1]
-                                dipole["z"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,2]
-                            if l==1:
-                                # Compute l=1 electronic contribution to the dipole
-                                # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates
-                                dipole[cart[im]] -= coefs[iaux+i] * dipole_integrals[(spe,l,n)]
-                            i += 1
+            i = 0
+            if average:
+                # Add contribution of nuclear pseudocharge to the dipole
+                dipole["x"] += pseudocharge_dict[spe] * coords[iat,0]
+                dipole["y"] += pseudocharge_dict[spe] * coords[iat,1]
+                dipole["z"] += pseudocharge_dict[spe] * coords[iat,2]
+            for l in range(lmax[spe]+1):
+                for n in range(nmax[(spe,l)]):
+                    for im in range(2*l+1):
+                        if l==0:
+                            if average:
+                                # rescale isotropic coefficients to conserve the electronic charge
+                                coefs[iaux+i] *= nele/charge
+                            else:
+                                # remove residual charge from the most diffuse isotropic function
+                                if n==nmax[(spe,l)]-1:
+                                    coefs[iaux+i] -= charge/(charge_integrals[(spe,l,n)]*natoms)
+                            # Compute l=0 electronic contribution to the dipole
+                            # NB: this is ill-defined in a truly periodic system and/or for systems with a net charge
+                            dipole["x"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,0]
+                            dipole["y"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,1]
+                            dipole["z"] -= coefs[iaux+i] * charge_integrals[(spe,l,n)] * coords[iat,2]
+                        if l==1:
+                            # Compute l=1 electronic contribution to the dipole
+                            # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates
+                            dipole[cart[im]] -= coefs[iaux+i] * dipole_integrals[(spe,l,n)]
+                        i += 1
         for l in range(lmax[spe]+1):
             for n in range(nmax[(spe,l)]):
                 iaux += 2*l+1
+
+    if parallel:
+        comm.Barrier()
+        dipole["x"] = comm.allreduce(dipole["x"])
+        dipole["y"] = comm.allreduce(dipole["y"])
+        dipole["z"] = comm.allreduce(dipole["z"])
 
     return [charge,dipole]
 
@@ -241,7 +239,6 @@ def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lma
     if parallel:
         comm.Barrier()
         grad_charge = comm.allreduce(grad_charge)
-        comm.Barrier()
 
     #print(f"Reduce time gc = {(time.time() - time_red_gc):.2f} s", flush=True)
 
@@ -270,14 +267,8 @@ def scale_grad_coefs(geom,pseudocharge,natoms,atoms_range_set,atomic_symbols,lma
 
     return
 
-def compute_polarizability(geom,natoms,atomic_symbols,lmax,nmax,species,charge_integrals,dipole_integrals,coefs):
+def compute_polarizability(geom,natoms,atomic_symbols,coords,lmax,nmax,species,charge_integrals,dipole_integrals,coefs):
     """Compute polarizability tensor for the given configuration"""
-
-    geom.wrap()
-    bohr2angs = 0.529177210670
-    coords = geom.get_positions()/bohr2angs
-    all_symbols = geom.get_chemical_symbols()
-    all_natoms = int(len(all_symbols))
 
     # Compute unnormalized response integral
     charge = {} 
@@ -304,25 +295,24 @@ def compute_polarizability(geom,natoms,atomic_symbols,lmax,nmax,species,charge_i
     for cartrow in ["x","y","z"]:
         ccoefs = coefs[cartrow]
         iaux = 0
-        for iat in range(all_natoms):
-            spe = all_symbols[iat]
-            if spe in species:
-                for l in range(lmax[spe]+1):
-                    for n in range(nmax[(spe,l)]):
-                        for im in range(2*l+1):
-                            if l==0:
-                                # remove residual charge from the most diffuse isotropic function
-                                if n==nmax[(spe,l)]-1:
-                                    ccoefs[iaux] -= charge[cartrow]/(charge_integrals[(spe,l,n)]*natoms)
-                                # Compute l=0 electronic contribution to the linear moment of the density-response 
-                                # NB: this is ill-defined in a truly periodic system 
-                                alpha[(cartrow,"x")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,0]
-                                alpha[(cartrow,"y")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,1]
-                                alpha[(cartrow,"z")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,2]
-                            if l==1:
-                                # Compute l=1 electronic contribution to the linear moment of the density-response  
-                                # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates 
-                                alpha[(cartrow,cart[im])] -= ccoefs[iaux] * dipole_integrals[(spe,l,n)]
-                            iaux += 1
+        for iat in range(natoms):
+            spe = atomic_symbols[iat]
+            for l in range(lmax[spe]+1):
+                for n in range(nmax[(spe,l)]):
+                    for im in range(2*l+1):
+                        if l==0:
+                            # remove residual charge from the most diffuse isotropic function
+                            if n==nmax[(spe,l)]-1:
+                                ccoefs[iaux] -= charge[cartrow]/(charge_integrals[(spe,l,n)]*natoms)
+                            # Compute l=0 electronic contribution to the linear moment of the density-response 
+                            # NB: this is ill-defined in a truly periodic system 
+                            alpha[(cartrow,"x")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,0]
+                            alpha[(cartrow,"y")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,1]
+                            alpha[(cartrow,"z")] -= ccoefs[iaux] * charge_integrals[(spe,l,n)] * coords[iat,2]
+                        if l==1:
+                            # Compute l=1 electronic contribution to the linear moment of the density-response  
+                            # NB: this follows the correspondence between (-1,0,1) real spherical harmonics and (y,z,x) Cartesian coordinates 
+                            alpha[(cartrow,cart[im])] -= ccoefs[iaux] * dipole_integrals[(spe,l,n)]
+                        iaux += 1
 
     return alpha

--- a/salted/get_averages.py
+++ b/salted/get_averages.py
@@ -9,7 +9,7 @@ def build():
 
     inp = ParseConfig().parse_input()
 
-    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
     avcoefs = {}
     nat_per_species = {}

--- a/salted/hessian_matrix.py
+++ b/salted/hessian_matrix.py
@@ -166,7 +166,7 @@ def matrices(trainrange,ntrain,av_coefs,rank):
             saltedpath, fdir, f"M{Menv}_zeta{zeta}", f"psi-nm_conf0.npz"
         ))
 
-    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_per_spe, natoms_per_spe = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     totsize = p.shape[-1]

--- a/salted/hessian_matrix.py
+++ b/salted/hessian_matrix.py
@@ -26,7 +26,7 @@ def build():
     saltedname, saltedpath = inp.salted.saltedname, inp.salted.saltedpath
     comm, size, rank, parallel = detect_mpi()
 
-    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
     rdir = f"regrdir_{saltedname}"
 

--- a/salted/minimize_loss.py
+++ b/salted/minimize_loss.py
@@ -71,7 +71,7 @@ def build():
     fdir = f"rkhs-vectors_{saltedname}"
     rdir = f"regrdir_{saltedname}"
 
-    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = (
+    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = (
         read_system()
     )
 

--- a/salted/ortho/ortho_error.py
+++ b/salted/ortho/ortho_error.py
@@ -8,7 +8,7 @@ from sys_utils import read_system
 sys.path.insert(0, './')
 import inp
 
-spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
 # number of sparse environments
 M = inp.Menv

--- a/salted/ortho/ortho_projections.py
+++ b/salted/ortho/ortho_projections.py
@@ -7,7 +7,7 @@ sys.path.insert(0, './')
 import inp
 from sys_utils import read_system, get_atom_idx
 
-spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 atom_idx, natoms_spe = get_atom_idx(ndata,natoms,spelist,atomic_symbols)
 
 #def add_command_line_arguments_contraction(parsetext):

--- a/salted/ortho/ortho_regression.py
+++ b/salted/ortho/ortho_regression.py
@@ -6,7 +6,7 @@ sys.path.insert(0, './')
 import inp
 from sys_utils import read_system, get_atom_idx
 
-spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 atom_idx, natom_dict = get_atom_idx(ndata,natoms,spelist,atomic_symbols)
 
 # number of sparse environments

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -48,7 +48,7 @@ def build():
 
     comm, size, rank, parallel = detect_mpi()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system(filename_pred, species, dfbasis)
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system(filename_pred, species, dfbasis)
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     bohr2angs = 0.529177210670
@@ -278,7 +278,7 @@ def build():
 
             if qmcode=="cp2k":
                 # Compute charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(frames[iconf],inp.qm.pseudocharge,natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average)
+                charge, dipole = compute_charge_and_dipole(frames[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
                 print(iconf+1,charge,file=qfile)
                 print(iconf+1,dipole["x"],dipole["y"],dipole["z"],file=dfile)
             

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -278,7 +278,7 @@ def build():
 
             if qmcode=="cp2k":
                 # Compute charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(frames[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
                 print(iconf+1,charge,file=qfile)
                 print(iconf+1,dipole["x"],dipole["y"],dipole["z"],file=dfile)
             
@@ -564,7 +564,7 @@ def build():
             
             if qmcode=="cp2k":
                 # Compute polarizability
-                alpha = compute_polarizability(frames[iconf],natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs)
+                alpha = compute_polarizability(natoms[iconf],atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs)
 
                 # Save polarizabilities
                 print(iconf+1, alpha[("x","x")],    alpha[("x","y")],    alpha[("x","z")],

--- a/salted/prediction.py
+++ b/salted/prediction.py
@@ -278,7 +278,7 @@ def build():
 
             if qmcode=="cp2k":
                 # Compute charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms[iconf]),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
                 print(iconf+1,charge,file=qfile)
                 print(iconf+1,dipole["x"],dipole["y"],dipole["z"],file=dfile)
             

--- a/salted/rkhs_projector.py
+++ b/salted/rkhs_projector.py
@@ -29,7 +29,7 @@ def build():
     zeta, Menv, Ntrain, trainfrac, regul, eigcut,
     gradtol, restart, trainsel, nspe1, nspe2, HP1, HP2) = ParseConfig().get_all_params()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     sdir = os.path.join(saltedpath, f"equirepr_{saltedname}")

--- a/salted/rkhs_vector.py
+++ b/salted/rkhs_vector.py
@@ -33,7 +33,7 @@ def build():
 
     comm, size, rank, parallel = detect_mpi()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     class arraylist:

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -9,7 +9,7 @@ from ase.io import read
 from scipy import special
 
 from salted import basis, sph_utils
-from salted.cp2k.utils import compute_charge_and_dipole, scale_grad_coefs
+from salted.cp2k.utils import compute_charge_and_dipole_parallelized, scale_grad_coefs
 from salted.sys_utils import ParseConfig, check_MPI_tasks_count, compute_Mcut, distribute_jobs, format_index_ranges
 
 def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,gradient,structure):
@@ -302,12 +302,6 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
     if average and rank==0:
         pred_coefs += Av_coeffs
     
-    if parallel:
-        comm.Barrier()
-        pred_coefs = comm.allreduce(pred_coefs)  
-        if gradient:
-            grad_pred_coefs = comm.allreduce(grad_pred_coefs)  
- 
     #print("pred time:", time.time()-predstart,flush=True)
     if inp.salted.verbose and rank==0:
         print(f"Total prediction time = {(time.time() - start_time):.2f} s", flush=True)
@@ -318,11 +312,11 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
         for spe in species:
             lcuts[spe] = min(lcut,lmax[spe])
  
-        charge, dipole = compute_charge_and_dipole(structure,inp.qm.pseudocharge,natoms,atomic_symbols,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average)
+        charge, dipole = compute_charge_and_dipole_parallelized(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_global_idx,atomic_symbols,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
         
         if gradient:
 
-            grad_charge = scale_grad_coefs(structure,inp.qm.pseudocharge,natoms,atomic_symbols,lcuts,nmax,species,charge_integrals,pred_coefs,grad_pred_coefs,average,charge)
+            grad_charge = scale_grad_coefs(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,lcuts,nmax,species,charge_integrals,pred_coefs,grad_pred_coefs,average,charge,parallel,comm)
 
             return [pred_coefs, grad_pred_coefs, charge, dipole] 
 

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -35,6 +35,7 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
     
     # Define system excluding atoms that belong to species not listed in SALTED input 
     atomic_symbols = structure.get_chemical_symbols()
+    structure.wrap()
     atomic_coords = structure.get_positions()/bohr2angs
     natoms_tot = len(atomic_symbols)
     excluded_species = []
@@ -317,11 +318,11 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
         for spe in species:
             lcuts[spe] = min(lcut,lmax[spe])
  
-        charge, dipole = compute_charge_and_dipole(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,atomic_coords,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+        charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,atomic_coords,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
         
         if gradient:
 
-            grad_charge = scale_grad_coefs(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,lcuts,nmax,species,charge_integrals,pred_coefs,grad_pred_coefs,average,charge,parallel,comm)
+            grad_charge = scale_grad_coefs(inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,lcuts,nmax,species,charge_integrals,pred_coefs,grad_pred_coefs,average,charge,parallel,comm)
 
             return [pred_coefs, grad_pred_coefs, charge, dipole] 
 

--- a/salted/salted_prediction.py
+++ b/salted/salted_prediction.py
@@ -9,7 +9,7 @@ from ase.io import read
 from scipy import special
 
 from salted import basis, sph_utils
-from salted.cp2k.utils import compute_charge_and_dipole_parallelized, scale_grad_coefs
+from salted.cp2k.utils import compute_charge_and_dipole, scale_grad_coefs
 from salted.sys_utils import ParseConfig, check_MPI_tasks_count, compute_Mcut, distribute_jobs, format_index_ranges
 
 def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_integrals,dipole_integrals,comm,size,rank,lcut,gradient,structure):
@@ -30,9 +30,12 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
 
     # read system
     ndata = len(structure)
+
+    bohr2angs = 0.529177210670
     
     # Define system excluding atoms that belong to species not listed in SALTED input 
     atomic_symbols = structure.get_chemical_symbols()
+    atomic_coords = structure.get_positions()/bohr2angs
     natoms_tot = len(atomic_symbols)
     excluded_species = []
     atomic_global_idx = []
@@ -44,7 +47,9 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
             atomic_global_idx.append(iat)
     excluded_species = set(excluded_species)
     for spe in excluded_species:
+        mask = [s != spe for s in atomic_symbols]
         atomic_symbols = list(filter(lambda a: a != spe, atomic_symbols))
+        atomic_coords = np.array(atomic_coords)[mask]
     natoms = int(len(atomic_symbols))
     atomic_global_idx = np.array(atomic_global_idx,int)
 
@@ -312,7 +317,7 @@ def build(lmax,nmax,lmax_max,weights,power_env_sparse,Mspe,Vmat,vfps,charge_inte
         for spe in species:
             lcuts[spe] = min(lcut,lmax[spe])
  
-        charge, dipole = compute_charge_and_dipole_parallelized(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_global_idx,atomic_symbols,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+        charge, dipole = compute_charge_and_dipole(structure,inp.qm.pseudocharge,natoms,atoms_range_set,atomic_symbols,atomic_coords,lcuts,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
         
         if gradient:
 

--- a/salted/scalar_vector.py
+++ b/salted/scalar_vector.py
@@ -36,7 +36,7 @@ def build():
         if not osp.exists(sdir):
             os.mkdir(sdir)
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     # Load feature space sparsification information if required

--- a/salted/sparse-gpr_energies.py
+++ b/salted/sparse-gpr_energies.py
@@ -12,7 +12,7 @@ def build(propname:str):
 
     inp = ParseConfig().parse_input()
     
-    spelist, lmax, nmax, llmax, nnmax, ndata, symbols, natoms, natmax = read_system()
+    spelist, lmax, nmax, llmax, nnmax, ndata, symbols, atomic_coords, natoms, natmax = read_system()
     
     xyzfile = read(inp.system.filename,":")
     

--- a/salted/sparse_descriptor.py
+++ b/salted/sparse_descriptor.py
@@ -42,7 +42,7 @@ def build():
 
     comm, size, rank, parallel = detect_mpi()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     frames = read(filename,":")

--- a/salted/sparse_selection.py
+++ b/salted/sparse_selection.py
@@ -9,7 +9,7 @@ from salted.sys_utils import ParseConfig, read_system, get_atom_idx, do_fps
 def build():
     inp = ParseConfig().parse_input()
 
-    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
 
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 

--- a/salted/sparsify_features.py
+++ b/salted/sparsify_features.py
@@ -41,7 +41,7 @@ def build():
         )
         sys.exit(1)
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     start = time.time()

--- a/salted/sys_utils.py
+++ b/salted/sys_utils.py
@@ -104,13 +104,18 @@ def read_system(filename: str = None, spelist: list[str] = None, dfbasis: str = 
     # read system
     xyzfile = read(filename, ":", parallel=False)
     ndata = len(xyzfile)
+    
+    bohr2angs = 0.529177210670
 
     # Define system excluding atoms that belong to species not listed in SALTED input
     atomic_symbols = []
+    atomic_coords  = []
     natoms = np.zeros(ndata, int)
     for iconf in range(len(xyzfile)):
         atomic_symbols.append(xyzfile[iconf].get_chemical_symbols())
         natoms_total = len(atomic_symbols[iconf])
+        xyzfile[iconf].wrap()
+        atomic_coords.append(xyzfile[iconf].get_positions()/bohr2angs)
         excluded_species = []
         for iat in range(natoms_total):
             spe = atomic_symbols[iconf][iat]
@@ -118,13 +123,15 @@ def read_system(filename: str = None, spelist: list[str] = None, dfbasis: str = 
                 excluded_species.append(spe)
         excluded_species = set(excluded_species)
         for spe in excluded_species:
+            mask = [s != spe for s in atomic_symbols[iconf]]
             atomic_symbols[iconf] = list(filter(lambda a: a != spe, atomic_symbols[iconf]))
+            atomic_coords[iconf] = np.array(atomic_coords[iconf])[mask]
         natoms[iconf] = int(len(atomic_symbols[iconf]))
 
     # Define maximum number of atoms
     natmax = max(natoms)
 
-    return spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, natoms, natmax
+    return spelist, lmax, nmax, llmax, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax
 
 
 def get_atom_idx(ndata, natoms, spelist, atomic_symbols):

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -34,7 +34,7 @@ def build():
 
     comm, size, rank, parallel = detect_mpi()
 
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     vdir = f"validations_{saltedname}"
@@ -156,9 +156,9 @@ def build():
             if qmcode=="cp2k":
 
                 # Compute reference total charges and dipole moments
-                ref_charge, ref_dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average)
+                ref_charge, ref_dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average,parallel,comm)
                 # Compute predicted total charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average)
+                charge, dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
 
 
                 # Save charges and dipole moments

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -156,9 +156,9 @@ def build():
             if qmcode=="cp2k":
 
                 # Compute reference total charges and dipole moments
-                ref_charge, ref_dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average,parallel,comm)
+                ref_charge, ref_dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average,parallel,comm)
                 # Compute predicted total charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(xyzfile[iconf],inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
 
 
                 # Save charges and dipole moments
@@ -215,8 +215,8 @@ def build():
             if qmcode=="cp2k":
 
                 # Compute reference and predicted polarizabilities
-                ref_alpha = compute_polarizability(xyzfile[iconf],natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs)
-                alpha = compute_polarizability(xyzfile[iconf],natoms[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs)
+                ref_alpha = compute_polarizability(natoms[iconf],atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs)
+                alpha = compute_polarizability(natoms[iconf],atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs)
 
                 # Save polarizabilities
                 print(iconf+1,ref_alpha[("x","x")],ref_alpha[("x","y")],ref_alpha[("x","z")],

--- a/salted/validation.py
+++ b/salted/validation.py
@@ -156,9 +156,9 @@ def build():
             if qmcode=="cp2k":
 
                 # Compute reference total charges and dipole moments
-                ref_charge, ref_dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average,parallel,comm)
+                ref_charge, ref_dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms[iconf]),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,ref_coefs,average,parallel,comm)
                 # Compute predicted total charges and dipole moments
-                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms),atomic_symbols[iconf],atomic_symbols[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
+                charge, dipole = compute_charge_and_dipole(inp.qm.pseudocharge,natoms[iconf],np.arange(natoms[iconf]),atomic_symbols[iconf],atomic_coords[iconf],lmax,nmax,species,charge_integrals,dipole_integrals,pred_coefs,average,parallel,comm)
 
 
                 # Save charges and dipole moments

--- a/salted/wigner.py
+++ b/salted/wigner.py
@@ -15,7 +15,7 @@ def build():
     inp = ParseConfig().parse_input()
 
     from salted.sys_utils import read_system, get_atom_idx
-    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, natoms, natmax = read_system()
+    species, lmax, nmax, lmax_max, nnmax, ndata, atomic_symbols, atomic_coords, natoms, natmax = read_system()
     atom_idx, natom_dict = get_atom_idx(ndata,natoms,species,atomic_symbols)
 
     nang1, nang2 = inp.descriptor.rep1.nang, inp.descriptor.rep2.nang


### PR DESCRIPTION
Remove all_reduce in salted_prediction to improve efficiency.

Parallelized version of compute_charge_and_dipole must be use in this case.